### PR TITLE
Do not fail if URL is ftp:// or other protocol

### DIFF
--- a/spec_cleaner/rpmpreamble.py
+++ b/spec_cleaner/rpmpreamble.py
@@ -386,20 +386,19 @@ class RpmPreamble(Section):
             orig_url = match.group(1)
             value = orig_url
 
-            if orig_url.startswith('https://') or self.minimal:
-                self._add_line_value_to('url', orig_url, key='URL')
-                return
-
             if orig_url.startswith('http://'):
                 https_url = orig_url.replace('http', 'https', 1)
             elif parse.urlparse(orig_url).scheme == '':
                 https_url = 'https://' + orig_url
+            else:
+                https_url = None
 
             response = None
             try:
-                response = urlopen(https_url)
-                if response.getcode() == 200:
-                    value = https_url
+                if https_url and not self.minimal:
+                    response = urlopen(https_url)
+                    if response.getcode() == 200:
+                        value = https_url
             # ssl.CertificateError is a subclass of SSLError in Python 3.7. In Python 3.6 it's not.
             except (error.URLError, SSLError, CertificateError):
                 pass

--- a/tests/in/url_https.spec
+++ b/tests/in/url_https.spec
@@ -36,3 +36,17 @@ Url: http://wrong.host.badssl.com/
 %package null
 Summary: Null cipher suite
 Url: http://null.badssl.com/
+
+# URL is FTP (issue#258)
+%package ftp
+Summary: Url is FTP
+Url: ftp://ftp.null.badssl.com/
+
+%package ftp1
+Summary: Url is FTP
+Url: ftp.null.badssl.com/
+
+# other prefix
+%package other
+Summary: Url is not http, https or ftp
+Url: abc://null.badssl.com/

--- a/tests/out-minimal/url_https.spec
+++ b/tests/out-minimal/url_https.spec
@@ -35,5 +35,17 @@ URL:            http://wrong.host.badssl.com/
 %package null
 Summary:        Null cipher suite
 URL:            http://null.badssl.com/
+# URL is FTP (issue#258)
+%package ftp
+Summary:        Url is FTP
+URL:            ftp://ftp.null.badssl.com/
+
+%package ftp1
+Summary:        Url is FTP
+URL:            ftp.null.badssl.com/
+# other prefix
+%package other
+Summary:        Url is not http, https or ftp
+URL:            abc://null.badssl.com/
 
 %changelog

--- a/tests/web/url_https.spec
+++ b/tests/web/url_https.spec
@@ -35,5 +35,17 @@ URL:            http://wrong.host.badssl.com/
 %package null
 Summary:        Null cipher suite
 URL:            http://null.badssl.com/
+# URL is FTP (issue#258)
+%package ftp
+Summary:        Url is FTP
+URL:            ftp://ftp.null.badssl.com/
+
+%package ftp1
+Summary:        Url is FTP
+URL:            ftp.null.badssl.com/
+# other prefix
+%package other
+Summary:        Url is not http, https or ftp
+URL:            abc://null.badssl.com/
 
 %changelog


### PR DESCRIPTION
Fix "http to https replacement" in rpmpreamble.py so it ignores
url that uses a different protocol than http or https.

fixes#258