### PR TITLE
Change libexecdir substitution to do /usr/libexec to %{_libexecdir}

### DIFF
--- a/spec_cleaner/__init__.py
+++ b/spec_cleaner/__init__.py
@@ -59,7 +59,6 @@ def process_args(argv: List[str]) -> Dict[str, Any]:
         '--no-curlification', action='store_true', help='do not convert variables bracketing (%%{macro}) and keep it as it was on the input'
     )
     parser.add_argument('--no-copyright', action='store_true', help='do not include official SUSE copyright hear and just keep what is present')
-    parser.add_argument('--libexecdir', action='store_true', help='convert /usr/lib to %%{_libexecdir}')
     parser.add_argument('--remove-groups', action='store_true', help='remove groups from the specfile.')
     parser.add_argument(
         '--copyright-year',

--- a/spec_cleaner/rpmregexp.py
+++ b/spec_cleaner/rpmregexp.py
@@ -177,7 +177,7 @@ class Regexp(object):
     re_prefix = re.compile(r'(?<!\w)/usr' + endmacro)
     re_bindir = re.compile(r'%{?_prefix}?/bin' + endmacro)
     re_sbindir = re.compile(r'%{?_prefix}?/sbin' + endmacro)
-    re_libexecdir = re.compile(r'%{?_prefix}?/lib' + endmacro)
+    re_libexecdir = re.compile(r'%{?_prefix}?/libexec' + endmacro)
     re_includedir = re.compile(r'%{?_prefix}?/include' + endmacro)
     re_datadir = re.compile(r'%{?_prefix}?/share' + endmacro)
     re_mandir = re.compile(r'%{?_datadir}?/man' + endmacro)

--- a/spec_cleaner/rpmsection.py
+++ b/spec_cleaner/rpmsection.py
@@ -22,7 +22,6 @@ class Section(object):
         spec: A string with the path to the processed specfile.
         minimal: A flag indicating whether we run in minimal mode (no intrusive operations).
         no_curlification: A flag indicating whether we want to convert variables to curly brackets.
-        libexecdir: A flag indicating whether we want convert /usr/lib to %%{_libexecdir}.
         reg: A Regexp object that holds all regexps that will be used in spec-cleaner.
         condition: A flag representing if we are in the conditional or not.
         _condition_counter: An int for counting in how many (nested) condition we currently are.
@@ -34,7 +33,6 @@ class Section(object):
         self.spec: str = options['specfile']
         self.minimal: bool = options['minimal']
         self.no_curlification: bool = options['no_curlification']
-        self.libexecdir: bool = options['libexecdir']
         self.reg: Regexp = options['reg']
         # Are we inside of conditional or not
         self.condition: bool = False
@@ -248,8 +246,7 @@ class Section(object):
         line = self.reg.re_prefix.sub(r'%{_prefix}\1', line)
         line = self.reg.re_bindir.sub(r'%{_bindir}\1', line)
         line = self.reg.re_sbindir.sub(r'%{_sbindir}\1', line)
-        if not self.minimal and self.libexecdir:
-            line = self.reg.re_libexecdir.sub(r'%{_libexecdir}\1', line)
+        line = self.reg.re_libexecdir.sub(r'%{_libexecdir}\1', line)
         line = self.reg.re_includedir.sub(r'%{_includedir}\1', line)
         line = self.reg.re_datadir.sub(r'%{_datadir}\1', line)
         line = self.reg.re_mandir.sub(r'%{_mandir}\1', line)

--- a/tests/acceptance-tests.py
+++ b/tests/acceptance-tests.py
@@ -49,7 +49,6 @@ class TestCompare(object):
         'minimal': False,
         'no_curlification': False,
         'no_copyright': True,
-        'libexecdir': True,
         'copyright_year': 2013,
         'remove_groups': False,
         'tex': False,

--- a/tests/in/prefix.spec
+++ b/tests/in/prefix.spec
@@ -2,7 +2,7 @@
 # local install
 python scons/scons.py PREFIX=/usr/local
 # more complicated case
-python scons/scons.py PREFIX=/usr/lib/test/usr
+python scons/scons.py PREFIX=/usr/libexec/test/usr
 # with spaces
 python scons/scons.py PREFIX=/usr blah
 # ending with newline

--- a/tests/in/rpathreplacement.spec
+++ b/tests/in/rpathreplacement.spec
@@ -6,7 +6,7 @@ mkdir -p %{buildroot}/usr/sbin
 %defattr(-,root,root)
 %doc ChangeLog README COPYING
 /usr/name/
-/usr/lib/name/
+/usr/libexec/name/
 /usr/lib64/name
 /usr/share/data/name
 /usr/include/name

--- a/tests/out-minimal/prefix.spec
+++ b/tests/out-minimal/prefix.spec
@@ -2,7 +2,7 @@
 # local install
 python scons/scons.py PREFIX=%{_prefix}/local
 # more complicated case
-python scons/scons.py PREFIX=%{_prefix}/lib/test/usr
+python scons/scons.py PREFIX=%{_libexecdir}/test/usr
 # with spaces
 python scons/scons.py PREFIX=%{_prefix} blah
 # ending with newline

--- a/tests/out-minimal/rpathreplacement.spec
+++ b/tests/out-minimal/rpathreplacement.spec
@@ -7,7 +7,7 @@ mkdir -p %{buildroot}%{_sbindir}
 %license COPYING
 %doc ChangeLog README
 %{_prefix}/name/
-%{_prefix}/lib/name/
+%{_libexecdir}/name/
 %{_libdir}/name
 %{_datadir}/data/name
 %{_includedir}/name


### PR DESCRIPTION
As `%_libexecdir` is now defined as `/usr/libexec` on Fedora, Mageia, and
will be on openSUSE shortly, there's no reason for the option to not
convert it, as the path is consistent. Thus, the flag has been removed
from the CLI to enable the behavior and it is always on now.