### PR TITLE
Exclude apache_rex_check from bracketing

### DIFF
--- a/data/excludes-bracketing.txt
+++ b/data/excludes-bracketing.txt
@@ -1,4 +1,5 @@
 add_maven_depmap
+apache_rex_check
 apache_test_module_start_apache
 apache_test_module_stop_apache
 apache_test_module_curl


### PR DESCRIPTION
This macro needs input from the command line, so will break when bracketed