### PR TITLE
Enforce coding policy

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,13 +4,14 @@ repos:
     hooks:
     - id: black
       language_version: python3.6
-      args: [--skip-string-normalization]
+      args: [--skip-string-normalization, --line-length=100]
 
 -   repo: https://gitlab.com/pycqa/flake8
     rev: 3.7.9
     hooks:
     - id: flake8
       additional_dependencies: [flake8-docstrings]
+      args: [--max-line-length=100]
 
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev:  'v0.761'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,18 @@
+repos:
+-   repo: https://github.com/psf/black
+    rev: 19.10b0
+    hooks:
+    - id: black
+      language_version: python3.6
+      args: [--skip-string-normalization]
+
+-   repo: https://gitlab.com/pycqa/flake8
+    rev: 3.7.9
+    hooks:
+    - id: flake8
+      additional_dependencies: [flake8-docstrings]
+
+-   repo: https://github.com/pre-commit/mirrors-mypy
+    rev:  'v0.761'
+    hooks:
+    - id: mypy                                                           

--- a/README.md
+++ b/README.md
@@ -5,54 +5,85 @@
 [![Coverage Status](https://coveralls.io/repos/github/rpm-software-management/spec-cleaner/badge.svg?branch=master)](https://coveralls.io/github/rpm-software-management/spec-cleaner?branch=master)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/rpm-software-management/spec-cleaner.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/rpm-software-management/spec-cleaner/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/rpm-software-management/spec-cleaner.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/rpm-software-management/spec-cleaner/context:python)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 
-spec-cleaner is a tool that cleans the given RPM spec file according to the style guide and returns the result. It's planned to be a replacement for `osc service localrun format_spec_file` and it is intended to provide the same or better features in order to be able to unify all the spec files in [OBS](https://build.opensuse.org/).
+spec-cleaner is a tool that cleans the given RPM spec file according to the style guide and returns the result.
 
-# Packages
-spec-cleaner is provided as an RPM package for openSUSE Leap ([15.0](https://build.opensuse.org/package/show/openSUSE:Leap:15.0:Update/spec-cleaner) and [15.1](https://build.opensuse.org/package/show/openSUSE:Leap:15.1:Update/spec-cleaner)) and [openSUSE Tumbleweed](https://build.opensuse.org/package/show/openSUSE:Factory/spec-cleaner). When the new spec-cleaner is released then the version updates are done for all maintained openSUSE codestreams. That means that there is always the latest version available as a package in OBS.
+It's used for [openSUSE](https://www.opensuse.org), where it's planned to be a replacement for `osc service localrun format_spec_file` and it is intended to provide the same or better features in order to be able to unify all the spec files in [OBS](https://build.opensuse.org/).
 
-The latest version is also available on [PyPI](https://pypi.org/project/spec_cleaner/). You can install it via `pip install spec-cleaner`.
+# Table of contents
+* [Installation and usage](#installation-and-usage)
+* [Tests](#tests)
+* [Contributing](#contributing)
+* [Versioning and releasing](#versioning-and-releasing)
+* [Authors](#authors)
+
+## Installation and usage
+
+### Installation
+The latest version is available on [PyPI](https://pypi.org/project/spec_cleaner/). It can be installed by running `pip install spec_cleaner`.
+
+spec-cleaner is also provided as an RPM package for openSUSE Leap ([15.0](https://build.opensuse.org/package/show/openSUSE:Leap:15.0:Update/spec-cleaner) and [15.1](https://build.opensuse.org/package/show/openSUSE:Leap:15.1:Update/spec-cleaner)) and [openSUSE Tumbleweed](https://build.opensuse.org/package/show/openSUSE:Factory/spec-cleaner). When the new version of spec-cleaner is released then the version updates are performed for all maintained openSUSE codestreams. That means that there is always the latest version available in openSUSE:Leap.
+
+### Usage
+Simply run `spec-cleaner -i <specfile>` to clean your specfile up.
 
 
-# Tests
+## Tests
 
-## Running the tests
-spec-cleaner provides quite an extensive testsuite. You can run these tests locally either directly via `pytest` or in a clean environment via`tox` where besides pytest also flake8 or mypy is called.
+### Running the tests
+spec-cleaner provides quite an extensive testsuite. You can run these tests locally either directly via `pytest` or in a clean environment via`tox` where besides pytest also `flake8` or `mypy` is called.
 
-### pytest
-Just install `python3-pytest`, `python3-pytest-cov` and `python3-pytest-sugar` (for a nice progress bar) and then run all test via:
+#### pytest
+Just install `python3-pytest`, `python3-pytest-cov` and `python3-pytest-sugar` (for a nice progress bar) and then run all tests via:
 
     pytest
 
-### tox
+#### tox
 Install `tox` and run
 
     tox
-for running tests for the test environments stated in `tox.ini` configuration file. Or you can run the tests for a specified environment (e.g. Python 3.7) via calling
+for running tests for the test environments stated in `tox.ini` configuration file. Or you can run the tests for a specified environment (e.g. Python 3.7) by calling
 
 	tox -epy37
 
 
-## Adding new tests
-When a new feature is added to spec-cleaner then a test for this piece of code must be added. See
-
-[how to write tests for spec-cleaner](TESTSUITE.md).
-
-## mypy
-
-Recently, optional static type checker support was implemented for the most important parts of the code. It runs automatically (using the recent mypy version) when you run `tox`. If you want to run it on your own, just install `python3-mypy` and run
-
-    mypy spec_cleaner
-
 ## Contributing
-You are more than welcome to contribute to this project. If your are not sure about your changes, feel free to create an issue where you can discuss it prior to the implementation.
+You are more than welcome to contribute to this project. If you are not sure about your changes, feel free to create an issue where you can discuss it before the implementation.
 
-When changing anything in the code, make sure that you don't forget to
-  * add proper comments and docstrings
-  * run and pass all tests, `flake8` and `mypy` (just run `tox`)
-  * add  [tests](TESTSUITE.md) (mainly if you implement a new feature)
-  * add `mypy` support for the new code
+### Contribution Guidelines
+
+When changing anything in the code, make sure that you don't forget to:
+
+  * Follow [pep8](https://www.python.org/dev/peps/pep-0008/).
+  * Install [pre-commit](https://pre-commit.com/) framework and run `pre-commit install` to install `pre-commit` into your git hooks.
+  * Add proper comments and docstrings (follow [pep257](https://www.python.org/dev/peps/pep-0257/) and [Google Python Style Guide for docstrings and comments](http://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings))
+  * Add [tests](TESTSUITE.md) (mainly if you implement a new feature).
+  * Add `mypy` support for the new code.
+  * Run and pass all tests, `flake8` and `mypy` checks (just run `tox` for all these checks).
+
+See below for more details.
+
+### pre-commit
+
+spec-cleaner project adopted `pre-commit` framework for managing and maintaining pre-commit hooks. After you clone the spec-cleaner repository, please install [pre-commit](https://pre-commit.com/) framework (`pip install pre-commit`) and run `pre-commit install` to install `pre-commit` into your git hooks. Then `pre-commit` will run automatically on `git commit` and it will check your contribution with `black`, `flake8`, `flake8-docstrings` and `mypy`.
+
+Please note that similar checks run in CI when you submit a PR and it won't pass code review without passing these checks.
+
+### mypy
+
+Optional static type checker support was implemented for the most important parts of the code. It runs automatically (using the recent mypy version) when you run `tox`. If you want to run it on your own, just install `python3-mypy` and run
+
+     mypy spec_cleaner
+
+### Black
+
+The code of spec-cleaner is formated with [Black](https://github.com/psf/black). We use default options, except for `--skip-string-normalization` option. Black runs automatically in the `pre-commit` hook.
+
+### Adding new tests
+When a new feature is added to spec-cleaner then a test for this piece of code must be added. See [how to write tests for spec-cleaner](TESTSUITE.md).
 
 
 ## Versioning and releasing
@@ -60,12 +91,10 @@ For the versions available, see the [tags on this repository](https://github.com
 
 If you have proper permissions you can find handy [how to do a new release](RELEASE.md).
 
-
 ## Authors
 
 * **Tomas Chvatal** [scarabeusiv](https://github.com/scarabeusiv)  - *Initial work*
-
-See also the list of [contributors](AUTHORS) who participated in this project.
+* See also the list of [contributors](AUTHORS) who participated in this project
 
 
 # [SPDX Licenses](http://spdx.org/licenses)

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Optional static type checker support was implemented for the most important part
 
 ### Black
 
-The code of spec-cleaner is formated with [Black](https://github.com/psf/black). We use default options, except for `--skip-string-normalization` option. Black runs automatically in the `pre-commit` hook.
+The code of spec-cleaner is formated with [Black](https://github.com/psf/black). We use `--skip-string-normalization` and `--line-length 100` options. Black runs automatically in the `pre-commit` hook.
 
 ### Adding new tests
 When a new feature is added to spec-cleaner then a test for this piece of code must be added. See [how to write tests for spec-cleaner](TESTSUITE.md).

--- a/README.md.in
+++ b/README.md.in
@@ -80,7 +80,7 @@ Optional static type checker support was implemented for the most important part
 
 ### Black
 
-The code of spec-cleaner is formated with [Black](https://github.com/psf/black). We use default options, except for `--skip-string-normalization` option. Black runs automatically in the `pre-commit` hook.
+The code of spec-cleaner is formated with [Black](https://github.com/psf/black). We use `--skip-string-normalization` and `--line-length 100` options. Black runs automatically in the `pre-commit` hook.
 
 ### Adding new tests
 When a new feature is added to spec-cleaner then a test for this piece of code must be added. See [how to write tests for spec-cleaner](TESTSUITE.md).

--- a/README.md.in
+++ b/README.md.in
@@ -5,54 +5,85 @@
 [![Coverage Status](https://coveralls.io/repos/github/rpm-software-management/spec-cleaner/badge.svg?branch=master)](https://coveralls.io/github/rpm-software-management/spec-cleaner?branch=master)
 [![Total alerts](https://img.shields.io/lgtm/alerts/g/rpm-software-management/spec-cleaner.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/rpm-software-management/spec-cleaner/alerts/)
 [![Language grade: Python](https://img.shields.io/lgtm/grade/python/g/rpm-software-management/spec-cleaner.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/rpm-software-management/spec-cleaner/context:python)
+[![pre-commit](https://img.shields.io/badge/pre--commit-enabled-brightgreen?logo=pre-commit&logoColor=white)](https://github.com/pre-commit/pre-commit)
+[![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 
 
-spec-cleaner is a tool that cleans the given RPM spec file according to the style guide and returns the result. It's planned to be a replacement for `osc service localrun format_spec_file` and it is intended to provide the same or better features in order to be able to unify all the spec files in [OBS](https://build.opensuse.org/).
+spec-cleaner is a tool that cleans the given RPM spec file according to the style guide and returns the result.
 
-# Packages
-spec-cleaner is provided as an RPM package for openSUSE Leap ([15.0](https://build.opensuse.org/package/show/openSUSE:Leap:15.0:Update/spec-cleaner) and [15.1](https://build.opensuse.org/package/show/openSUSE:Leap:15.1:Update/spec-cleaner)) and [openSUSE Tumbleweed](https://build.opensuse.org/package/show/openSUSE:Factory/spec-cleaner). When the new spec-cleaner is released then the version updates are done for all maintained openSUSE codestreams. That means that there is always the latest version available as a package in OBS.
+It's used for [openSUSE](https://www.opensuse.org), where it's planned to be a replacement for `osc service localrun format_spec_file` and it is intended to provide the same or better features in order to be able to unify all the spec files in [OBS](https://build.opensuse.org/).
 
-The latest version is also available on [PyPI](https://pypi.org/project/spec_cleaner/). You can install it via `pip install spec-cleaner`.
+# Table of contents
+* [Installation and usage](#installation-and-usage)
+* [Tests](#tests)
+* [Contributing](#contributing)
+* [Versioning and releasing](#versioning-and-releasing)
+* [Authors](#authors)
+
+## Installation and usage
+
+### Installation
+The latest version is available on [PyPI](https://pypi.org/project/spec_cleaner/). It can be installed by running `pip install spec_cleaner`.
+
+spec-cleaner is also provided as an RPM package for openSUSE Leap ([15.0](https://build.opensuse.org/package/show/openSUSE:Leap:15.0:Update/spec-cleaner) and [15.1](https://build.opensuse.org/package/show/openSUSE:Leap:15.1:Update/spec-cleaner)) and [openSUSE Tumbleweed](https://build.opensuse.org/package/show/openSUSE:Factory/spec-cleaner). When the new version of spec-cleaner is released then the version updates are performed for all maintained openSUSE codestreams. That means that there is always the latest version available in openSUSE:Leap.
+
+### Usage
+Simply run `spec-cleaner -i <specfile>` to clean your specfile up.
 
 
-# Tests
+## Tests
 
-## Running the tests
-spec-cleaner provides quite an extensive testsuite. You can run these tests locally either directly via `pytest` or in a clean environment via`tox` where besides pytest also flake8 or mypy is called.
+### Running the tests
+spec-cleaner provides quite an extensive testsuite. You can run these tests locally either directly via `pytest` or in a clean environment via`tox` where besides pytest also `flake8` or `mypy` is called.
 
-### pytest
-Just install `python3-pytest`, `python3-pytest-cov` and `python3-pytest-sugar` (for a nice progress bar) and then run all test via:
+#### pytest
+Just install `python3-pytest`, `python3-pytest-cov` and `python3-pytest-sugar` (for a nice progress bar) and then run all tests via:
 
     pytest
 
-### tox
+#### tox
 Install `tox` and run
 
     tox
-for running tests for the test environments stated in `tox.ini` configuration file. Or you can run the tests for a specified environment (e.g. Python 3.7) via calling
+for running tests for the test environments stated in `tox.ini` configuration file. Or you can run the tests for a specified environment (e.g. Python 3.7) by calling
 
 	tox -epy37
 
 
-## Adding new tests
-When a new feature is added to spec-cleaner then a test for this piece of code must be added. See
-
-[how to write tests for spec-cleaner](TESTSUITE.md).
-
-## mypy
-
-Recently, optional static type checker support was implemented for the most important parts of the code. It runs automatically (using the recent mypy version) when you run `tox`. If you want to run it on your own, just install `python3-mypy` and run
-
-    mypy spec_cleaner
-
 ## Contributing
-You are more than welcome to contribute to this project. If your are not sure about your changes, feel free to create an issue where you can discuss it prior to the implementation.
+You are more than welcome to contribute to this project. If you are not sure about your changes, feel free to create an issue where you can discuss it before the implementation.
 
-When changing anything in the code, make sure that you don't forget to
-  * add proper comments and docstrings
-  * run and pass all tests, `flake8` and `mypy` (just run `tox`)
-  * add  [tests](TESTSUITE.md) (mainly if you implement a new feature)
-  * add `mypy` support for the new code
+### Contribution Guidelines
+
+When changing anything in the code, make sure that you don't forget to:
+
+  * Follow [pep8](https://www.python.org/dev/peps/pep-0008/).
+  * Install [pre-commit](https://pre-commit.com/) framework and run `pre-commit install` to install `pre-commit` into your git hooks.
+  * Add proper comments and docstrings (follow [pep257](https://www.python.org/dev/peps/pep-0257/) and [Google Python Style Guide for docstrings and comments](http://google.github.io/styleguide/pyguide.html#38-comments-and-docstrings))
+  * Add [tests](TESTSUITE.md) (mainly if you implement a new feature).
+  * Add `mypy` support for the new code.
+  * Run and pass all tests, `flake8` and `mypy` checks (just run `tox` for all these checks).
+
+See below for more details.
+
+### pre-commit
+
+spec-cleaner project adopted `pre-commit` framework for managing and maintaining pre-commit hooks. After you clone the spec-cleaner repository, please install [pre-commit](https://pre-commit.com/) framework (`pip install pre-commit`) and run `pre-commit install` to install `pre-commit` into your git hooks. Then `pre-commit` will run automatically on `git commit` and it will check your contribution with `black`, `flake8`, `flake8-docstrings` and `mypy`.
+
+Please note that similar checks run in CI when you submit a PR and it won't pass code review without passing these checks.
+
+### mypy
+
+Optional static type checker support was implemented for the most important parts of the code. It runs automatically (using the recent mypy version) when you run `tox`. If you want to run it on your own, just install `python3-mypy` and run
+
+     mypy spec_cleaner
+
+### Black
+
+The code of spec-cleaner is formated with [Black](https://github.com/psf/black). We use default options, except for `--skip-string-normalization` option. Black runs automatically in the `pre-commit` hook.
+
+### Adding new tests
+When a new feature is added to spec-cleaner then a test for this piece of code must be added. See [how to write tests for spec-cleaner](TESTSUITE.md).
 
 
 ## Versioning and releasing
@@ -60,10 +91,8 @@ For the versions available, see the [tags on this repository](https://github.com
 
 If you have proper permissions you can find handy [how to do a new release](RELEASE.md).
 
-
 ## Authors
 
 * **Tomas Chvatal** [scarabeusiv](https://github.com/scarabeusiv)  - *Initial work*
-
-See also the list of [contributors](AUTHORS) who participated in this project.
+* See also the list of [contributors](AUTHORS) who participated in this project
 

--- a/devel-requirements.pip
+++ b/devel-requirements.pip
@@ -10,6 +10,7 @@ flake8-import-order
 flake8-quotes
 mypy
 pep8-naming
+pre-commit
 pytest
 pytest-cov
 pytest-xdist

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,5 +2,5 @@
 test=pytest
 
 [flake8]
-ignore = E402,E501,E502,W503,W504
+ignore = E402,E501,E502,W503,W504,D413
 import-order-style = google

--- a/spec_cleaner/__init__.py
+++ b/spec_cleaner/__init__.py
@@ -35,31 +35,63 @@ def process_args(argv: List[str]) -> Dict[str, Any]:
         prog='spec-cleaner',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
         description='Cleans the given spec file according to style guide and returns the result. If "#nospeccleaner"'
-                    'tag is used in the spec file than the spec file will not be cleaned.',
+        'tag is used in the spec file than the spec file will not be cleaned.',
     )
 
     # Make the -d, -i, and -o exclusive as we can do only one of those
     output_group = parser.add_mutually_exclusive_group()
 
-    parser.add_argument('specfile', metavar='SPEC', type=str, help='spec file to beautify')
+    parser.add_argument(
+        'specfile', metavar='SPEC', type=str, help='spec file to beautify'
+    )
     parser.add_argument(
         '-c',
         '--cmake',
         action='store_true',
         help='convert dependencies to their cmake() counterparts, requires bit more of cleanup in spec afterwards.',
     )
-    output_group.add_argument('-d', '--diff', action='store_true', help='run the diff program to show differences between new and original specfile.')
-    parser.add_argument('--diff-prog', default='vimdiff', help='specify the diff binary to call with diff option.')
-    parser.add_argument('-f', '--force', action='store_true', help='overwrite the output file if already exist.')
-    output_group.add_argument('-i', '--inline', action='store_true', help='inline the changes directly to the parsed file.')
-    parser.add_argument(
-        '-m', '--minimal', action='store_true', help='run in minimal mode that does not do anything intrusive (ie. just sets the Copyright)'
+    output_group.add_argument(
+        '-d',
+        '--diff',
+        action='store_true',
+        help='run the diff program to show differences between new and original specfile.',
     )
     parser.add_argument(
-        '--no-curlification', action='store_true', help='do not convert variables bracketing (%%{macro}) and keep it as it was on the input'
+        '--diff-prog',
+        default='vimdiff',
+        help='specify the diff binary to call with diff option.',
     )
-    parser.add_argument('--no-copyright', action='store_true', help='do not include official SUSE copyright hear and just keep what is present')
-    parser.add_argument('--remove-groups', action='store_true', help='remove groups from the specfile.')
+    parser.add_argument(
+        '-f',
+        '--force',
+        action='store_true',
+        help='overwrite the output file if already exist.',
+    )
+    output_group.add_argument(
+        '-i',
+        '--inline',
+        action='store_true',
+        help='inline the changes directly to the parsed file.',
+    )
+    parser.add_argument(
+        '-m',
+        '--minimal',
+        action='store_true',
+        help='run in minimal mode that does not do anything intrusive (ie. just sets the Copyright)',
+    )
+    parser.add_argument(
+        '--no-curlification',
+        action='store_true',
+        help='do not convert variables bracketing (%%{macro}) and keep it as it was on the input',
+    )
+    parser.add_argument(
+        '--no-copyright',
+        action='store_true',
+        help='do not include official SUSE copyright hear and just keep what is present',
+    )
+    parser.add_argument(
+        '--remove-groups', action='store_true', help='remove groups from the specfile.'
+    )
     parser.add_argument(
         '--copyright-year',
         metavar='YYYY',
@@ -67,19 +99,42 @@ def process_args(argv: List[str]) -> Dict[str, Any]:
         default=datetime.now().year,
         help='year to insert into the copyright header when re-generating it',
     )
-    output_group.add_argument('-o', '--output', default='', help='specify the output file for the cleaned spec content.')
+    output_group.add_argument(
+        '-o',
+        '--output',
+        default='',
+        help='specify the output file for the cleaned spec content.',
+    )
     parser.add_argument(
         '-p',
         '--pkgconfig',
         action='store_true',
         help='convert dependencies to their pkgconfig() counterparts, requires bit more of cleanup in spec afterwards.',
     )
-    parser.add_argument('--perl', action='store_true', help='convert dependencies to their perl() counterparts, highly expansive use carefully')
     parser.add_argument(
-        '-t', '--tex', action='store_true', help='convert dependencies to their tex() counterparts, requires verification of the output afterwards.'
+        '--perl',
+        action='store_true',
+        help='convert dependencies to their perl() counterparts, highly expansive use carefully',
     )
-    parser.add_argument('-v', '--version', action='version', version=__version__, help='show package version and exit')
-    parser.add_argument('-k', '--keep-space', action='store_true', help='keep empty lines in preamble intact.')
+    parser.add_argument(
+        '-t',
+        '--tex',
+        action='store_true',
+        help='convert dependencies to their tex() counterparts, requires verification of the output afterwards.',
+    )
+    parser.add_argument(
+        '-v',
+        '--version',
+        action='version',
+        version=__version__,
+        help='show package version and exit',
+    )
+    parser.add_argument(
+        '-k',
+        '--keep-space',
+        action='store_true',
+        help='keep empty lines in preamble intact.',
+    )
 
     # print help if there is no argument
     if len(argv) < 1:

--- a/spec_cleaner/__init__.py
+++ b/spec_cleaner/__init__.py
@@ -106,10 +106,11 @@ def process_args(argv: List[str]) -> Dict[str, Any]:
 
 def main() -> int:
     """
-    Main function that calls argument parsing ensures their sanity
-    and then creates RpmSpecCleaner object that works with passed spec file.
-    """
+    Run main function.
 
+    It calls argument parsing ensures their sanity and then creates
+    RpmSpecCleaner object that works with passed spec file.
+    """
     try:
         options = process_args(sys.argv[1:])
     except RpmWrongArgs as exception:

--- a/spec_cleaner/__init__.py
+++ b/spec_cleaner/__init__.py
@@ -41,9 +41,7 @@ def process_args(argv: List[str]) -> Dict[str, Any]:
     # Make the -d, -i, and -o exclusive as we can do only one of those
     output_group = parser.add_mutually_exclusive_group()
 
-    parser.add_argument(
-        'specfile', metavar='SPEC', type=str, help='spec file to beautify'
-    )
+    parser.add_argument('specfile', metavar='SPEC', type=str, help='spec file to beautify')
     parser.add_argument(
         '-c',
         '--cmake',
@@ -57,15 +55,10 @@ def process_args(argv: List[str]) -> Dict[str, Any]:
         help='run the diff program to show differences between new and original specfile.',
     )
     parser.add_argument(
-        '--diff-prog',
-        default='vimdiff',
-        help='specify the diff binary to call with diff option.',
+        '--diff-prog', default='vimdiff', help='specify the diff binary to call with diff option.',
     )
     parser.add_argument(
-        '-f',
-        '--force',
-        action='store_true',
-        help='overwrite the output file if already exist.',
+        '-f', '--force', action='store_true', help='overwrite the output file if already exist.',
     )
     output_group.add_argument(
         '-i',
@@ -100,10 +93,7 @@ def process_args(argv: List[str]) -> Dict[str, Any]:
         help='year to insert into the copyright header when re-generating it',
     )
     output_group.add_argument(
-        '-o',
-        '--output',
-        default='',
-        help='specify the output file for the cleaned spec content.',
+        '-o', '--output', default='', help='specify the output file for the cleaned spec content.',
     )
     parser.add_argument(
         '-p',
@@ -130,10 +120,7 @@ def process_args(argv: List[str]) -> Dict[str, Any]:
         help='show package version and exit',
     )
     parser.add_argument(
-        '-k',
-        '--keep-space',
-        action='store_true',
-        help='keep empty lines in preamble intact.',
+        '-k', '--keep-space', action='store_true', help='keep empty lines in preamble intact.',
     )
 
     # print help if there is no argument

--- a/spec_cleaner/dependency_parser.py
+++ b/spec_cleaner/dependency_parser.py
@@ -10,31 +10,11 @@ state_types = ('start', 'name', 'operator', 'version')
 
 re_brackets = {}
 re_brackets['('] = re.compile(
-    r'('
-    + r'\('
-    + r'|'
-    + r'\)'
-    + r'|'
-    + r'\\('
-    + r'|'
-    + r'\\)'
-    + r'|'
-    + r'[^\()]+'
-    + r')'
+    r'(' + r'\(' + r'|' + r'\)' + r'|' + r'\\(' + r'|' + r'\\)' + r'|' + r'[^\()]+' + r')'
 )
 
 re_brackets['{'] = re.compile(
-    r'('
-    + r'\{'
-    + r'|'
-    + r'\}'
-    + r'|'
-    + r'\\{'
-    + r'|'
-    + r'\\}'
-    + r'|'
-    + r'[^\{}]+'
-    + r')'
+    r'(' + r'\{' + r'|' + r'\}' + r'|' + r'\\{' + r'|' + r'\\}' + r'|' + r'[^\{}]+' + r')'
 )
 
 re_name = re.compile(r'[-A-Za-z0-9_~(){}@:;.+/*\[\]]+')
@@ -81,8 +61,7 @@ def consume_chars(regex, string):
         return string[0:end], string[end:]
     else:
         raise NoMatchException(
-            'Expected match failed (string: "%s", regex: "%s" )'
-            % (string, regex.pattern)
+            'Expected match failed (string: "%s", regex: "%s" )' % (string, regex.pattern)
         )
 
 
@@ -96,8 +75,7 @@ def matching_bracket(bracket):
     elif bracket == '(':
         return ')'
     raise Exception(
-        'Undefined bracket matching - add defintion of "%s" to '
-        'matching_bracket()' % bracket
+        'Undefined bracket matching - add defintion of "%s" to ' 'matching_bracket()' % bracket
     )
 
 

--- a/spec_cleaner/dependency_parser.py
+++ b/spec_cleaner/dependency_parser.py
@@ -9,9 +9,33 @@ chunk_types = ('text', 'space', 'macro', 'operator', 'version')
 state_types = ('start', 'name', 'operator', 'version')
 
 re_brackets = {}
-re_brackets['('] = re.compile(r'(' + r'\(' + r'|' + r'\)' + r'|' + r'\\(' + r'|' + r'\\)' + r'|' + r'[^\()]+' + r')')
+re_brackets['('] = re.compile(
+    r'('
+    + r'\('
+    + r'|'
+    + r'\)'
+    + r'|'
+    + r'\\('
+    + r'|'
+    + r'\\)'
+    + r'|'
+    + r'[^\()]+'
+    + r')'
+)
 
-re_brackets['{'] = re.compile(r'(' + r'\{' + r'|' + r'\}' + r'|' + r'\\{' + r'|' + r'\\}' + r'|' + r'[^\{}]+' + r')')
+re_brackets['{'] = re.compile(
+    r'('
+    + r'\{'
+    + r'|'
+    + r'\}'
+    + r'|'
+    + r'\\{'
+    + r'|'
+    + r'\\}'
+    + r'|'
+    + r'[^\{}]+'
+    + r')'
+)
 
 re_name = re.compile(r'[-A-Za-z0-9_~(){}@:;.+/*\[\]]+')
 re_version = re.compile(r'[-A-Za-z0-9_~():.+]+')
@@ -56,7 +80,10 @@ def consume_chars(regex, string):
         end = match.end()
         return string[0:end], string[end:]
     else:
-        raise NoMatchException('Expected match failed (string: "%s", regex: "%s" )' % (string, regex.pattern))
+        raise NoMatchException(
+            'Expected match failed (string: "%s", regex: "%s" )'
+            % (string, regex.pattern)
+        )
 
 
 def read_boolean(string):
@@ -68,7 +95,10 @@ def matching_bracket(bracket):
         return '}'
     elif bracket == '(':
         return ')'
-    raise Exception('Undefined bracket matching - add defintion of "%s" to ' 'matching_bracket()' % bracket)
+    raise Exception(
+        'Undefined bracket matching - add defintion of "%s" to '
+        'matching_bracket()' % bracket
+    )
 
 
 def read_macro(string):

--- a/spec_cleaner/rpmbuild.py
+++ b/spec_cleaner/rpmbuild.py
@@ -5,10 +5,7 @@ from .rpmcheck import RpmCheck
 
 
 class RpmBuild(RpmCheck):
-
-    """
-    A class providing methods for %build section cleaning.
-    """
+    """A class providing methods for %build section cleaning."""
 
     def add(self, line: str) -> None:
         # we do not want to run suseupdateconfig, deprecated
@@ -23,7 +20,7 @@ class RpmBuild(RpmCheck):
 
     def _comment_macro_calls(self, line: str) -> None:
         """
-        Add a comment if the package uses direct call of certain build tools instead of macro.
+        Add a comment if the package uses direct call of build tools instead of macro.
 
         Args:
             line: A string representing a line to process.

--- a/spec_cleaner/rpmcheck.py
+++ b/spec_cleaner/rpmcheck.py
@@ -4,7 +4,6 @@ from .rpmsection import Section
 
 
 class RpmCheck(Section):
-
     """
     A class providing methods for %check section cleaning.
 
@@ -47,7 +46,6 @@ class RpmCheck(Section):
         Return:
             The processed line.
         """
-
         # if it is comment line then do nothing
         if line.lstrip().startswith('#'):
             return line

--- a/spec_cleaner/rpmcleaner.py
+++ b/spec_cleaner/rpmcleaner.py
@@ -36,10 +36,11 @@ from .rpmsection import Section
 
 
 class RpmSpecCleaner(object):
-
     """
-    Class wrapping all section parsers responsible for ensuring
-    that all sections are checked and accounted for.
+    Class wrapping all sections parser is responsible for.
+
+    It ensures that all sections are checked and accounted for.
+
     If the section is required and not found it is created with
     blank values as fixme for the spec creator.
 
@@ -48,14 +49,20 @@ class RpmSpecCleaner(object):
         fin: An in-memory input stream with the input file data.
         fout: A file object representing output file.
         current_section: A Section object representing current section of spec file.
-        skip_run: A bool indicating whether the cleaning of the specfile should be skipped.
-        options: A dictionary holding both spec-cleaner commandline arguments and auxiliary options.
+        skip_run: A bool indicating whether the cleaning of the specfile should be
+                 skipped.
+        options: A dictionary holding both spec-cleaner commandline arguments and
+                 auxiliary options.
         reg: A Regexp object that holds all regexps that will be used in spec-cleaner.
-        section_starts: A list of tuples where the first item is regex object representing a start of the specfile
-                        section and the second is a corresponding class that should handle it.
-        _previous_line: A string holding the previous line of the currently processed specfile.
-        _previous_nonempty_line: A string holding a nonempty previous line of the currently processed specfile.
+        section_starts: A list of tuples where the first item is regex object
+                       representing a start of the specfile section and the second is
+                       a corresponding class that should handle it.
+        _previous_line: A string holding the previous line of the currently processed
+                        specfile.
+        _previous_nonempty_line: A string holding a nonempty previous line of the
+                                 currently processed specfile.
     """
+
     specfile: Optional[str] = None
     current_section: Section
     skip_run: bool = False
@@ -63,8 +70,7 @@ class RpmSpecCleaner(object):
     _previous_nonempty_line: Optional[str] = None
 
     def __init__(self, options: Dict[str, Any]) -> None:
-
-        """Initialize and load options into the RpmSpecCleaner object and runs prep methods.
+        """Initialize and load options into the RpmSpecCleaner obj and run prep methods.
 
         Args:
             options: A dictionary holding spec-cleaner command line options.
@@ -163,9 +169,10 @@ class RpmSpecCleaner(object):
 
     def _find_skip_parser(self) -> None:
         """
-        Search the specfile for the user defined '#nospeccleaner' tag (means that specfile shouldn't be cleaned).
+        Search the specfile for the user defined '#nospeccleaner' tag.
 
-        If the tag is found then skip_run member is set to True, else it's False.
+        This tag means that specfile shouldn't be cleaned. If the tag is found then
+        skip_run member is set to True, else it's False.
         """
         for line in self.fin:
             if self.reg.re_skipcleaner.match(line):
@@ -219,7 +226,9 @@ class RpmSpecCleaner(object):
 
     def _detect_condition_change(self, line: str) -> bool:
         """
-        Detect if the line contains a condition change (e.g. '%endif', '%else' or the end of the code block).
+        Detect if the line contains a condition change.
+
+        (e.g. '%endif', '%else' or the end of the code block)
 
         Args:
             line: A string representing a line to process.
@@ -323,7 +332,8 @@ class RpmSpecCleaner(object):
                 return True
 
     def run(self) -> None:
-        """ The main spec-cleaner method.
+        """
+        Run the main spec-cleaner method.
 
         Raises:
             RpmException if a diff program can't be executed.
@@ -386,10 +396,7 @@ class RpmSpecCleaner(object):
                 raise RpmException('Could not execute %s (%s)' % (self.options['diff_prog'].split()[0], error.strerror))
 
     def __del__(self) -> None:
-        """
-        Close the input and output files.
-        """
-
+        """Close the input and output files."""
         if self.fin:
             self.fin.close()
         if self.fout:

--- a/spec_cleaner/rpmcleaner.py
+++ b/spec_cleaner/rpmcleaner.py
@@ -105,10 +105,7 @@ class RpmSpecCleaner(object):
         self.options['reg'] = Regexp(self.options['unbrace_keywords'])
 
         # If gvim is used for the diff then run it in foreground mode
-        if (
-            self.options['diff_prog'].startswith('gvim')
-            and ' -f' not in self.options['diff_prog']
-        ):
+        if self.options['diff_prog'].startswith('gvim') and ' -f' not in self.options['diff_prog']:
             self.options['diff_prog'] += ' -f'
 
         self.reg = self.options['reg']
@@ -152,9 +149,7 @@ class RpmSpecCleaner(object):
             self.fout = open(self.options['specfile'], 'w')
         elif self.options['diff']:
             self.fout = tempfile.NamedTemporaryFile(
-                mode='w+',
-                prefix=os.path.split(self.options['specfile'])[-1] + '.',
-                suffix='.spec',
+                mode='w+', prefix=os.path.split(self.options['specfile'])[-1] + '.', suffix='.spec',
             )
         else:
             self.fout = sys.stdout
@@ -221,15 +216,13 @@ class RpmSpecCleaner(object):
         """
         # This is seriously ugly but can't think of cleaner way FIXME
         if not isinstance(self.current_section, (RpmPreamble, RpmPackage)):
-            if any(
-                re.match(line) for re in [self.reg.re_bcond_with, self.reg.re_debugpkg]
-            ):
+            if any(re.match(line) for re in [self.reg.re_bcond_with, self.reg.re_debugpkg]):
                 return True
 
             # We can have locally defined variables in phases
-            if not isinstance(
-                self.current_section, (RpmInstall, RpmCheck, RpmBuild, RpmPrep)
-            ) and (self.reg.re_define.match(line) or self.reg.re_global.match(line)):
+            if not isinstance(self.current_section, (RpmInstall, RpmCheck, RpmBuild, RpmPrep)) and (
+                self.reg.re_define.match(line) or self.reg.re_global.match(line)
+            ):
                 return True
         return False
 
@@ -247,11 +240,7 @@ class RpmSpecCleaner(object):
         """
         if any(
             re.match(line)
-            for re in [
-                self.reg.re_endif,
-                self.reg.re_else_elif,
-                self.reg.re_endcodeblock,
-            ]
+            for re in [self.reg.re_endif, self.reg.re_else_elif, self.reg.re_endcodeblock]
         ):
             return True
         return False
@@ -285,8 +274,7 @@ class RpmSpecCleaner(object):
             and (self.reg.re_if.match(line) or self.reg.re_codeblock.match(line))
         ):
             if not hasattr(self.current_section, 'condition') or (
-                hasattr(self.current_section, 'condition')
-                and not self.current_section.condition
+                hasattr(self.current_section, 'condition') and not self.current_section.condition
             ):
                 # If we have to break out we go ahead with small class
                 # which just print the one evil line
@@ -297,10 +285,7 @@ class RpmSpecCleaner(object):
             if regexp.match(line):
                 # check if we are in if conditional and act accordingly if we
                 # change sections
-                if (
-                    hasattr(self.current_section, 'condition')
-                    and self.current_section.condition
-                ):
+                if hasattr(self.current_section, 'condition') and self.current_section.condition:
                     self.current_section.condition = False
                     if hasattr(self.current_section, 'end_subparagraph'):
                         # mypy: we need to ignore type check here because mypy cannot detect that we are checking the
@@ -332,9 +317,7 @@ class RpmSpecCleaner(object):
         # we are staying in the section
         return None
 
-    def _check_for_newline(
-        self, detected_class: Optional[Type[Section]], line: str
-    ) -> bool:
+    def _check_for_newline(self, detected_class: Optional[Type[Section]], line: str) -> bool:
         """
         Check if we want newline or not after the end of section detected.
 
@@ -392,9 +375,7 @@ class RpmSpecCleaner(object):
             # sys.stderr.write("class: '{0}' line: '{1}'\n".format(new_class, line))
             if new_class:
                 self.current_section.output(
-                    self.fout,
-                    self._check_for_newline(new_class, line),
-                    new_class.__name__,
+                    self.fout, self._check_for_newline(new_class, line), new_class.__name__,
                 )
                 # start new class
                 self.current_section = new_class(self.options)

--- a/spec_cleaner/rpmcopyright.py
+++ b/spec_cleaner/rpmcopyright.py
@@ -7,7 +7,6 @@ from .rpmsection import Section
 
 
 class RpmCopyright(Section):
-
     """
     A class providing methods for copyright section cleaning.
 

--- a/spec_cleaner/rpmdescription.py
+++ b/spec_cleaner/rpmdescription.py
@@ -5,7 +5,6 @@ from .rpmsection import Section
 
 
 class RpmDescription(Section):
-
     """
     A class providing methods for %description section cleaning.
 

--- a/spec_cleaner/rpmexception.py
+++ b/spec_cleaner/rpmexception.py
@@ -2,10 +2,7 @@
 
 
 class RpmBaseException(Exception):
-
-    """
-    Class wrapping Exception class so we throw neat exceptions.
-    """
+    """Class wrapping Exception class so we throw neat exceptions."""
 
     def __init__(self, args=()) -> None:
         Exception.__init__(self)
@@ -16,21 +13,12 @@ class RpmBaseException(Exception):
 
 
 class RpmWrongArgs(RpmBaseException):
-
-    """
-    Exception raised by wrong arguments passed by cli.
-    """
+    """Exception raised by wrong arguments passed by cli."""
 
 
 class RpmException(RpmBaseException):
-
-    """
-    Exception raised by wrong parsed content from rpm.
-    """
+    """Exception raised by wrong parsed content from rpm."""
 
 
 class NoMatchException(RpmBaseException):
-
-    """
-    Exception raised by not matching corresponding brackets/etc.
-    """
+    """Exception raised by not matching corresponding brackets/etc."""

--- a/spec_cleaner/rpmfiles.py
+++ b/spec_cleaner/rpmfiles.py
@@ -4,10 +4,8 @@ from .rpmsection import Section
 
 
 class RpmFiles(Section):
+    """A class providing methods for %files section cleaning."""
 
-    """
-    A class providing methods for %files section cleaning.
-    """
     def add(self, line: str) -> None:
         line = self._complete_cleanup(line)
         line = self.strip_useless_spaces(line)
@@ -46,8 +44,9 @@ class RpmFiles(Section):
 
     def _set_man_compression(self, line: str) -> str:
         """
-        Set proper compression suffix on man/info pages, instead of .gz/.* use
-        the proper macro variable.
+        Set proper compression suffix on man/info pages.
+
+        Instead of .gz/.* use the proper macro variable.
 
         Args:
            line: A string representing a line to process.

--- a/spec_cleaner/rpmhelpers.py
+++ b/spec_cleaner/rpmhelpers.py
@@ -187,9 +187,7 @@ def sort_uniq(seq):
 
 
 def add_group(group):
-    """
-    Flatten the lines of the group from sublits to one simple list
-    """
+    """Flatten the lines of the group from sublits to one simple list."""
     if isinstance(group, str):
         return [group]
     elif isinstance(group, RpmRequiresToken):
@@ -217,7 +215,6 @@ def find_pkgconfig_statement(elements):
     Returns:
         True if pkgconfig() statement was found (and pkgconfig declaration wasn't), False otherwise.
     """
-
     pkgconfig_found = find_pkgconfig_declaration(elements)
     for i in elements:
         if isinstance(i, RpmRequiresToken):

--- a/spec_cleaner/rpmhelpers.py
+++ b/spec_cleaner/rpmhelpers.py
@@ -105,10 +105,7 @@ def read_licenses_changes() -> Dict[str, str]:
     """
     with open_datafile(LICENSES_CHANGES) as f:
         next(f)  # strip newline
-        return {
-            old: correct
-            for correct, old in (line.rstrip('\n').split('\t') for line in f)
-        }
+        return {old: correct for correct, old in (line.rstrip('\n').split('\t') for line in f)}
 
 
 def read_group_changes():

--- a/spec_cleaner/rpmhelpers.py
+++ b/spec_cleaner/rpmhelpers.py
@@ -105,7 +105,10 @@ def read_licenses_changes() -> Dict[str, str]:
     """
     with open_datafile(LICENSES_CHANGES) as f:
         next(f)  # strip newline
-        return {old: correct for correct, old in (line.rstrip('\n').split('\t') for line in f)}
+        return {
+            old: correct
+            for correct, old in (line.rstrip('\n').split('\t') for line in f)
+        }
 
 
 def read_group_changes():
@@ -136,7 +139,14 @@ def fix_license(value, conversions):
         licenses[index] = my_license
 
     # create back new string with replaced licenses
-    s = ' '.join(licenses).replace('( ', '(').replace(' )', ')').replace(' and ', ' AND ').replace(' or ', ' OR ').replace(' with ', ' WITH ')
+    s = (
+        ' '.join(licenses)
+        .replace('( ', '(')
+        .replace(' )', ')')
+        .replace(' and ', ' AND ')
+        .replace(' or ', ' OR ')
+        .replace(' with ', ' WITH ')
+    )
     return s
 
 

--- a/spec_cleaner/rpminstall.py
+++ b/spec_cleaner/rpminstall.py
@@ -57,11 +57,8 @@ class RpmInstall(Section):
         Return:
             The processed line.
         """
-        if (
-            self.reg.re_rm.search(line) and len(self.reg.re_rm_double.split(line)) == 1
-        ) or (
-            self.reg.re_find.search(line)
-            and len(self.reg.re_find_double.split(line)) == 2
+        if (self.reg.re_rm.search(line) and len(self.reg.re_rm_double.split(line)) == 1) or (
+            self.reg.re_find.search(line) and len(self.reg.re_find_double.split(line)) == 2
         ):
             line = 'find %{buildroot} -type f -name "*.la" -delete -print'
         return line

--- a/spec_cleaner/rpminstall.py
+++ b/spec_cleaner/rpminstall.py
@@ -57,8 +57,11 @@ class RpmInstall(Section):
         Return:
             The processed line.
         """
-        if (self.reg.re_rm.search(line) and len(self.reg.re_rm_double.split(line)) == 1) or (
-            self.reg.re_find.search(line) and len(self.reg.re_find_double.split(line)) == 2
+        if (
+            self.reg.re_rm.search(line) and len(self.reg.re_rm_double.split(line)) == 1
+        ) or (
+            self.reg.re_find.search(line)
+            and len(self.reg.re_find_double.split(line)) == 2
         ):
             line = 'find %{buildroot} -type f -name "*.la" -delete -print'
         return line

--- a/spec_cleaner/rpminstall.py
+++ b/spec_cleaner/rpminstall.py
@@ -4,7 +4,6 @@ from .rpmsection import Section
 
 
 class RpmInstall(Section):
-
     """
     A class providing methods for %install section cleaning.
 

--- a/spec_cleaner/rpmpackage.py
+++ b/spec_cleaner/rpmpackage.py
@@ -24,10 +24,7 @@ class RpmPackage(RpmPreamble):
             len(self.lines) == 1
             and (
                 self.previous_line.startswith('%')
-                and (
-                    self.previous_line.endswith(' lang')
-                    or self.previous_line.endswith('-lang')
-                )
+                and (self.previous_line.endswith(' lang') or self.previous_line.endswith('-lang'))
             )
             and not line.startswith('#')
         ):

--- a/spec_cleaner/rpmpackage.py
+++ b/spec_cleaner/rpmpackage.py
@@ -22,7 +22,13 @@ class RpmPackage(RpmPreamble):
         # package
         if (
             len(self.lines) == 1
-            and (self.previous_line.startswith('%') and (self.previous_line.endswith(' lang') or self.previous_line.endswith('-lang')))
+            and (
+                self.previous_line.startswith('%')
+                and (
+                    self.previous_line.endswith(' lang')
+                    or self.previous_line.endswith('-lang')
+                )
+            )
             and not line.startswith('#')
         ):
             if not self.minimal:

--- a/spec_cleaner/rpmpackage.py
+++ b/spec_cleaner/rpmpackage.py
@@ -5,7 +5,6 @@ from .rpmsection import Section
 
 
 class RpmPackage(RpmPreamble):
-
     """
     A class providing methods for %package section cleaning.
 

--- a/spec_cleaner/rpmpreamble.py
+++ b/spec_cleaner/rpmpreamble.py
@@ -204,10 +204,7 @@ class RpmPreamble(Section):
         else:
             nested = True
         lines = self.paragraph.flatten_output(False, nested)
-        if (
-            len(self.paragraph.items['define']) > 0
-            or len(self.paragraph.items['bconds']) > 0
-        ):
+        if len(self.paragraph.items['define']) > 0 or len(self.paragraph.items['bconds']) > 0:
             self._condition_define = True
         self.paragraph = self._oldstore.pop(-1)
         self.paragraph.items['conditions'] += lines
@@ -222,9 +219,7 @@ class RpmPreamble(Section):
                 # we need to put it bellow bcond definitions as otherwise
                 # the switches do not have any effect
                 if self._condition_bcond:
-                    self.paragraph.items['bcond_conditions'] += self.paragraph.items[
-                        'conditions'
-                    ]
+                    self.paragraph.items['bcond_conditions'] += self.paragraph.items['conditions']
                 elif len(self.paragraph.items['define']) == 0:
                     self.paragraph.items['bconds'] += self.paragraph.items['conditions']
                 else:
@@ -235,13 +230,9 @@ class RpmPreamble(Section):
                     self._condition_define = False
             else:
                 if self._pattern_condition:
-                    self.paragraph.items['patterncodeblock'] += self.paragraph.items[
-                        'conditions'
-                    ]
+                    self.paragraph.items['patterncodeblock'] += self.paragraph.items['conditions']
                 else:
-                    self.paragraph.items['build_conditions'] += self.paragraph.items[
-                        'conditions'
-                    ]
+                    self.paragraph.items['build_conditions'] += self.paragraph.items['conditions']
 
             # bcond must be reseted when on top and can be set even outside of the
             # define scope. So reset it here always
@@ -276,9 +267,7 @@ class RpmPreamble(Section):
                 and not self.previous_line.startswith('#')
                 and not self.minimal
             ):
-                self.paragraph.current_group.append(
-                    '# FIXME: Use %requires_eq macro instead'
-                )
+                self.paragraph.current_group.append('# FIXME: Use %requires_eq macro instead')
             return [value]
         tokens = DependencyParser(value).flat_out()
         # loop over all and do formatting as we can get more deps for one
@@ -302,17 +291,11 @@ class RpmPreamble(Section):
                 # checking if it is not list is simple avoidance of running
                 # over already converted values
                 if not isinstance(token, list) and self.perl:
-                    token = self._pkgname_to_brackety(
-                        token, 'perl', self.perl_conversions
-                    )
+                    token = self._pkgname_to_brackety(token, 'perl', self.perl_conversions)
                 if not isinstance(token, list) and self.tex:
-                    token = self._pkgname_to_brackety(
-                        token, 'tex', self.tex_conversions
-                    )
+                    token = self._pkgname_to_brackety(token, 'tex', self.tex_conversions)
                 if not isinstance(token, list) and self.cmake:
-                    token = self._pkgname_to_brackety(
-                        token, 'cmake', self.cmake_conversions
-                    )
+                    token = self._pkgname_to_brackety(token, 'cmake', self.cmake_conversions)
             if isinstance(token, list):
                 expanded += token
             else:
@@ -407,9 +390,7 @@ class RpmPreamble(Section):
             self.previous_line = line
             return
 
-        elif self.reg.re_comment.match(line) and not self.reg.re_buildignores.match(
-            line
-        ):
+        elif self.reg.re_comment.match(line) and not self.reg.re_buildignores.match(line):
             if line or self.previous_line:
                 self.paragraph.current_group.append(line)
                 self.previous_line = line
@@ -459,9 +440,7 @@ class RpmPreamble(Section):
             else:
                 zero = ''
             self._add_line_value_to(
-                'patch',
-                match.group(3),
-                key='%sPatch%s%s' % (match.group(1), zero, match.group(2)),
+                'patch', match.group(3), key='%sPatch%s%s' % (match.group(1), zero, match.group(2)),
             )
             return
 
@@ -482,16 +461,12 @@ class RpmPreamble(Section):
             self._add_line_value_to('patternprovides', match.group(1), key='Provides')
             return
 
-        elif self.reg.re_provides.match(line) and self.reg.re_patternobsolete.search(
-            line
-        ):
+        elif self.reg.re_provides.match(line) and self.reg.re_patternobsolete.search(line):
             match = self.reg.re_provides.match(line)
             self._add_line_value_to('patternobsoletes', match.group(1), key='Provides')
             return
 
-        elif self.reg.re_obsoletes.match(line) and self.reg.re_patternobsolete.search(
-            line
-        ):
+        elif self.reg.re_obsoletes.match(line) and self.reg.re_patternobsolete.search(line):
             match = self.reg.re_obsoletes.match(line)
             self._add_line_value_to('patternobsoletes', match.group(1), key='Obsoletes')
             return
@@ -571,16 +546,12 @@ class RpmPreamble(Section):
 
         elif self.reg.re_provides.match(line):
             match = self.reg.re_provides.match(line)
-            self._add_line_value_to(
-                'provides_obsoletes', match.group(1), key='Provides'
-            )
+            self._add_line_value_to('provides_obsoletes', match.group(1), key='Provides')
             return
 
         elif self.reg.re_obsoletes.match(line):
             match = self.reg.re_obsoletes.match(line)
-            self._add_line_value_to(
-                'provides_obsoletes', match.group(1), key='Obsoletes'
-            )
+            self._add_line_value_to('provides_obsoletes', match.group(1), key='Obsoletes')
             return
 
         elif self.reg.re_license.match(line):
@@ -608,9 +579,7 @@ class RpmPreamble(Section):
             language = match.group(1)
             # and what value is there
             content = match.group(2)
-            self._add_line_value_to(
-                'summary_localized', content, key='Summary{0}'.format(language)
-            )
+            self._add_line_value_to('summary_localized', content, key='Summary{0}'.format(language))
             return
 
         elif self.reg.re_group.match(line):

--- a/spec_cleaner/rpmpreamble.py
+++ b/spec_cleaner/rpmpreamble.py
@@ -14,7 +14,6 @@ from .rpmsection import Section
 
 
 class RpmPreamble(Section):
-
     """
     A class providing methods for preamble section cleaning.
 
@@ -128,9 +127,7 @@ class RpmPreamble(Section):
         self.paragraph = RpmPreambleElements(self.options)
 
     def _prune_ppc_condition(self):
-        """
-        Check if we have ppc64 obsolete and delete it
-        """
+        """Check if we have ppc64 obsolete and delete it."""
         if (
             not self.minimal
             and len(self.paragraph.items['conditions']) == 3
@@ -141,9 +138,7 @@ class RpmPreamble(Section):
             self.paragraph.items['conditions'] = []
 
     def _prune_empty_condition(self):
-        """
-        Remove empty conditions
-        """
+        """Remove empty conditions."""
         # check if we start with if
         if len(self.paragraph.items['conditions']) == 2 and (
             (isinstance(self.paragraph.items['conditions'][0], list) and self.paragraph.items['conditions'][0][-1].startswith('%if'))
@@ -155,8 +150,9 @@ class RpmPreamble(Section):
 
     def _fix_pypi_source(self, url):
         """
-        Check if the source is URL that points to PyPI and if it is, return
-        the canonical version.
+        Check if the source is URL that points to PyPI.
+
+        If it is, return the canonical version.
 
         This function is almost completely self-contained and only processes
         the URL structure itself. On PyPI, the structure is predictable.

--- a/spec_cleaner/rpmpreamble.py
+++ b/spec_cleaner/rpmpreamble.py
@@ -141,7 +141,10 @@ class RpmPreamble(Section):
         """Remove empty conditions."""
         # check if we start with if
         if len(self.paragraph.items['conditions']) == 2 and (
-            (isinstance(self.paragraph.items['conditions'][0], list) and self.paragraph.items['conditions'][0][-1].startswith('%if'))
+            (
+                isinstance(self.paragraph.items['conditions'][0], list)
+                and self.paragraph.items['conditions'][0][-1].startswith('%if')
+            )
             or self.paragraph.items['conditions'][0].startswith('%if')
         ):
             self.paragraph.items['conditions'] = []
@@ -184,7 +187,16 @@ class RpmPreamble(Section):
                 # don't know what to do
                 return url
 
-        return parse.urlunparse(('https', 'files.pythonhosted.org', '/packages/source/{}/{}/{}'.format(modname[0], modname, filename), '', '', ''))
+        return parse.urlunparse(
+            (
+                'https',
+                'files.pythonhosted.org',
+                '/packages/source/{}/{}/{}'.format(modname[0], modname, filename),
+                '',
+                '',
+                '',
+            )
+        )
 
     def end_subparagraph(self, endif=False):
         if not self._oldstore:
@@ -192,7 +204,10 @@ class RpmPreamble(Section):
         else:
             nested = True
         lines = self.paragraph.flatten_output(False, nested)
-        if len(self.paragraph.items['define']) > 0 or len(self.paragraph.items['bconds']) > 0:
+        if (
+            len(self.paragraph.items['define']) > 0
+            or len(self.paragraph.items['bconds']) > 0
+        ):
             self._condition_define = True
         self.paragraph = self._oldstore.pop(-1)
         self.paragraph.items['conditions'] += lines
@@ -207,7 +222,9 @@ class RpmPreamble(Section):
                 # we need to put it bellow bcond definitions as otherwise
                 # the switches do not have any effect
                 if self._condition_bcond:
-                    self.paragraph.items['bcond_conditions'] += self.paragraph.items['conditions']
+                    self.paragraph.items['bcond_conditions'] += self.paragraph.items[
+                        'conditions'
+                    ]
                 elif len(self.paragraph.items['define']) == 0:
                     self.paragraph.items['bconds'] += self.paragraph.items['conditions']
                 else:
@@ -218,9 +235,13 @@ class RpmPreamble(Section):
                     self._condition_define = False
             else:
                 if self._pattern_condition:
-                    self.paragraph.items['patterncodeblock'] += self.paragraph.items['conditions']
+                    self.paragraph.items['patterncodeblock'] += self.paragraph.items[
+                        'conditions'
+                    ]
                 else:
-                    self.paragraph.items['build_conditions'] += self.paragraph.items['conditions']
+                    self.paragraph.items['build_conditions'] += self.paragraph.items[
+                        'conditions'
+                    ]
 
             # bcond must be reseted when on top and can be set even outside of the
             # define scope. So reset it here always
@@ -250,8 +271,14 @@ class RpmPreamble(Section):
         # we do fix the package list only if there is no rpm call there on line
         # otherwise print there warning about nicer content and skip
         if self.reg.re_rpm_command.search(value):
-            if category == 'requires' and not self.previous_line.startswith('#') and not self.minimal:
-                self.paragraph.current_group.append('# FIXME: Use %requires_eq macro instead')
+            if (
+                category == 'requires'
+                and not self.previous_line.startswith('#')
+                and not self.minimal
+            ):
+                self.paragraph.current_group.append(
+                    '# FIXME: Use %requires_eq macro instead'
+                )
             return [value]
         tokens = DependencyParser(value).flat_out()
         # loop over all and do formatting as we can get more deps for one
@@ -269,15 +296,23 @@ class RpmPreamble(Section):
                 # the strings by some optimistic value of brackety dep
                 # priority is based on the first come first serve
                 if self.pkgconfig:
-                    token = self._pkgname_to_brackety(token, 'pkgconfig', self.pkgconfig_conversions)
+                    token = self._pkgname_to_brackety(
+                        token, 'pkgconfig', self.pkgconfig_conversions
+                    )
                 # checking if it is not list is simple avoidance of running
                 # over already converted values
                 if not isinstance(token, list) and self.perl:
-                    token = self._pkgname_to_brackety(token, 'perl', self.perl_conversions)
+                    token = self._pkgname_to_brackety(
+                        token, 'perl', self.perl_conversions
+                    )
                 if not isinstance(token, list) and self.tex:
-                    token = self._pkgname_to_brackety(token, 'tex', self.tex_conversions)
+                    token = self._pkgname_to_brackety(
+                        token, 'tex', self.tex_conversions
+                    )
                 if not isinstance(token, list) and self.cmake:
-                    token = self._pkgname_to_brackety(token, 'cmake', self.cmake_conversions)
+                    token = self._pkgname_to_brackety(
+                        token, 'cmake', self.cmake_conversions
+                    )
             if isinstance(token, list):
                 expanded += token
             else:
@@ -372,7 +407,9 @@ class RpmPreamble(Section):
             self.previous_line = line
             return
 
-        elif self.reg.re_comment.match(line) and not self.reg.re_buildignores.match(line):
+        elif self.reg.re_comment.match(line) and not self.reg.re_buildignores.match(
+            line
+        ):
             if line or self.previous_line:
                 self.paragraph.current_group.append(line)
                 self.previous_line = line
@@ -421,7 +458,11 @@ class RpmPreamble(Section):
                 zero = '0'
             else:
                 zero = ''
-            self._add_line_value_to('patch', match.group(3), key='%sPatch%s%s' % (match.group(1), zero, match.group(2)))
+            self._add_line_value_to(
+                'patch',
+                match.group(3),
+                key='%sPatch%s%s' % (match.group(1), zero, match.group(2)),
+            )
             return
 
         elif self.reg.re_bcond_with.match(line):
@@ -441,12 +482,16 @@ class RpmPreamble(Section):
             self._add_line_value_to('patternprovides', match.group(1), key='Provides')
             return
 
-        elif self.reg.re_provides.match(line) and self.reg.re_patternobsolete.search(line):
+        elif self.reg.re_provides.match(line) and self.reg.re_patternobsolete.search(
+            line
+        ):
             match = self.reg.re_provides.match(line)
             self._add_line_value_to('patternobsoletes', match.group(1), key='Provides')
             return
 
-        elif self.reg.re_obsoletes.match(line) and self.reg.re_patternobsolete.search(line):
+        elif self.reg.re_obsoletes.match(line) and self.reg.re_patternobsolete.search(
+            line
+        ):
             match = self.reg.re_obsoletes.match(line)
             self._add_line_value_to('patternobsoletes', match.group(1), key='Obsoletes')
             return
@@ -473,7 +518,11 @@ class RpmPreamble(Section):
             self._add_line_value_to('requires_ge', value)
             return
 
-        elif self.reg.re_define.match(line) or self.reg.re_global.match(line) or self.reg.re_onelinecond.match(line):
+        elif (
+            self.reg.re_define.match(line)
+            or self.reg.re_global.match(line)
+            or self.reg.re_onelinecond.match(line)
+        ):
             if line.endswith('\\'):
                 self.multiline = True
             # if we are kernel and not multiline we need to be at bottom, so
@@ -484,7 +533,9 @@ class RpmPreamble(Section):
                 self._add_line_to('define', line)
 
             # catch "modname" for use in pypi url rewriting
-            if (line.startswith('%define') or line.startswith('%global')) and line.find('modname') >= 0:
+            if (line.startswith('%define') or line.startswith('%global')) and line.find(
+                'modname'
+            ) >= 0:
                 define, name, value = line.split(None, 2)
                 self.modname = value
 
@@ -513,17 +564,23 @@ class RpmPreamble(Section):
                 value = 'shadow'
             else:
                 value = match.group(2)
-            self._add_line_value_to('requires_phase', value, key='Requires{0}'.format(match.group(1)))
+            self._add_line_value_to(
+                'requires_phase', value, key='Requires{0}'.format(match.group(1))
+            )
             return
 
         elif self.reg.re_provides.match(line):
             match = self.reg.re_provides.match(line)
-            self._add_line_value_to('provides_obsoletes', match.group(1), key='Provides')
+            self._add_line_value_to(
+                'provides_obsoletes', match.group(1), key='Provides'
+            )
             return
 
         elif self.reg.re_obsoletes.match(line):
             match = self.reg.re_obsoletes.match(line)
-            self._add_line_value_to('provides_obsoletes', match.group(1), key='Obsoletes')
+            self._add_line_value_to(
+                'provides_obsoletes', match.group(1), key='Obsoletes'
+            )
             return
 
         elif self.reg.re_license.match(line):
@@ -551,7 +608,9 @@ class RpmPreamble(Section):
             language = match.group(1)
             # and what value is there
             content = match.group(2)
-            self._add_line_value_to('summary_localized', content, key='Summary{0}'.format(language))
+            self._add_line_value_to(
+                'summary_localized', content, key='Summary{0}'.format(language)
+            )
             return
 
         elif self.reg.re_group.match(line):
@@ -563,11 +622,15 @@ class RpmPreamble(Section):
             match = self.reg.re_group.match(line)
             value = match.group(1)
             if not self.minimal and self.allowed_groups:
-                if self.previous_line and not self.previous_line.startswith(
-                        '# FIXME') and value not in self.allowed_groups:
+                if (
+                    self.previous_line
+                    and not self.previous_line.startswith('# FIXME')
+                    and value not in self.allowed_groups
+                ):
                     self.paragraph.current_group.append(
                         '# FIXME: use correct group or remove it,'
-                        ' see "https://en.opensuse.org/openSUSE:Package_group_guidelines"')
+                        ' see "https://en.opensuse.org/openSUSE:Package_group_guidelines"'
+                    )
             self._add_line_value_to('group', value)
             return
 

--- a/spec_cleaner/rpmpreambleelements.py
+++ b/spec_cleaner/rpmpreambleelements.py
@@ -1,7 +1,13 @@
 # vim: set ts=4 sw=4 et: coding=UTF-8
 
 from .rpmexception import RpmException
-from .rpmhelpers import add_group, find_pkgconfig_declaration, find_pkgconfig_statement, fix_license, sort_uniq
+from .rpmhelpers import (
+    add_group,
+    find_pkgconfig_declaration,
+    find_pkgconfig_statement,
+    fix_license,
+    sort_uniq,
+)
 from .rpmrequirestoken import RpmRequiresToken
 
 
@@ -121,7 +127,9 @@ class RpmPreambleElements(object):
         # dict of license replacement options
         self.license_conversions = options['license_conversions']
         # initialize list of groups that need to pass over conversion fixer
-        self.categories_with_package_tokens = self.categories_with_sorted_package_tokens[:]
+        self.categories_with_package_tokens = self.categories_with_sorted_package_tokens[
+            :
+        ]
         # these packages actually need fixing after we sent the values to
         # reorder them
         self.categories_with_package_tokens.append('provides_obsoletes')
@@ -180,7 +188,9 @@ class RpmPreambleElements(object):
             self.br_pkgconfig_required = True
         # only in case we are in main scope
         if not nested:
-            if self.br_pkgconfig_required and not find_pkgconfig_declaration(buildrequires):
+            if self.br_pkgconfig_required and not find_pkgconfig_declaration(
+                buildrequires
+            ):
                 self._insert_value('buildrequires', 'pkgconfig')
 
     @staticmethod
@@ -240,7 +250,10 @@ class RpmPreambleElements(object):
                 # names and prefix must always match
                 if item.name == element.name and item.prefix == element.prefix:
                     # do we have full match on everything
-                    if item.version == element.version and item.operator == element.operator:
+                    if (
+                        item.version == element.version
+                        and item.operator == element.operator
+                    ):
                         # append comment if needed only as we are 100% match
                         if element.comments:
                             tmp = results[index]

--- a/spec_cleaner/rpmpreambleelements.py
+++ b/spec_cleaner/rpmpreambleelements.py
@@ -8,6 +8,7 @@ from .rpmrequirestoken import RpmRequiresToken
 class RpmPreambleElements(object):
     """
     Class containing structure used in rpmpreamble.
+
     List of all the elements possible to be provided in dict and list forms.
     """
 
@@ -155,17 +156,17 @@ class RpmPreambleElements(object):
         return key
 
     def _insert_value(self, category, value, key=None):
-        """
-        Add value to specified keystore
-        """
+        """Add value to specified keystore."""
         key = self.compile_category_prefix(category, key)
         line = RpmRequiresToken(value, None, None, key)
         self.items[category].append(line)
 
     def _add_pkgconfig_buildrequires(self, nested):
         """
-        Check the content of buildrequires and add pkgconfig as an item
-        in case there are any pkgconfig() style dependencies present
+        Check the content of buildrequires and add pkgconfig if needed.
+
+        It adds pkgconfig as an item in case there are any pkgconfig() style
+        dependencies present.
 
         If we are in the top level object for preamble we append the BR,
         otherwise we do just verify if there are nay dependencies
@@ -185,8 +186,9 @@ class RpmPreambleElements(object):
     @staticmethod
     def _verify_prereq_message(elements):
         """
-        Verify if the prereq is present in the Requires(*) and add the fixme
-        comment if needed
+        Verify if prereq is present in Requires(*).
+
+        Add "fixme" comment if needed.
         """
         message = '# FIXME: use proper Requires(pre/post/preun/...)'
 
@@ -218,9 +220,7 @@ class RpmPreambleElements(object):
 
     @staticmethod
     def _remove_duplicates(elements):
-        """
-        Remove duplicate requires/buildrequires/etc
-        """
+        """Remove duplicate requires/buildrequires/etc."""
         results = []
         for element in elements:
             match = False
@@ -271,8 +271,10 @@ class RpmPreambleElements(object):
 
     def _run_global_list_operations(self, phase, elements):
         """
+        Run all the needed checks on the finalized sorted list.
+
         Run all the checks that need to be run on the finalized sorted list
-        rather than on invidiual value
+        rather than on invidiual value.
         """
         # check if we need to add comment for the prereq
         if not self.minimal and phase == 'prereq':
@@ -282,8 +284,10 @@ class RpmPreambleElements(object):
 
     def compile_category_prefix(self, category, key=None):
         """
-        Simply compile the category key and provide enough whitespace for the
-        values to be alligned
+        Provide enough whitespace so the values are aligned.
+
+        Simply compile the category key and provide enough whitespace for the values
+        to be aligned.
         """
         keylen = len('BuildRequires:  ')
 
@@ -308,9 +312,7 @@ class RpmPreambleElements(object):
         return key
 
     def flatten_output(self, needs_license=False, nested=False):
-        """
-        Do the finalized output for the itemlist.
-        """
+        """Do the finalized output for the itemlist."""
         lines = []
         elements = []
 

--- a/spec_cleaner/rpmpreambleelements.py
+++ b/spec_cleaner/rpmpreambleelements.py
@@ -127,9 +127,7 @@ class RpmPreambleElements(object):
         # dict of license replacement options
         self.license_conversions = options['license_conversions']
         # initialize list of groups that need to pass over conversion fixer
-        self.categories_with_package_tokens = self.categories_with_sorted_package_tokens[
-            :
-        ]
+        self.categories_with_package_tokens = self.categories_with_sorted_package_tokens[:]
         # these packages actually need fixing after we sent the values to
         # reorder them
         self.categories_with_package_tokens.append('provides_obsoletes')
@@ -188,9 +186,7 @@ class RpmPreambleElements(object):
             self.br_pkgconfig_required = True
         # only in case we are in main scope
         if not nested:
-            if self.br_pkgconfig_required and not find_pkgconfig_declaration(
-                buildrequires
-            ):
+            if self.br_pkgconfig_required and not find_pkgconfig_declaration(buildrequires):
                 self._insert_value('buildrequires', 'pkgconfig')
 
     @staticmethod
@@ -250,10 +246,7 @@ class RpmPreambleElements(object):
                 # names and prefix must always match
                 if item.name == element.name and item.prefix == element.prefix:
                     # do we have full match on everything
-                    if (
-                        item.version == element.version
-                        and item.operator == element.operator
-                    ):
+                    if item.version == element.version and item.operator == element.operator:
                         # append comment if needed only as we are 100% match
                         if element.comments:
                             tmp = results[index]

--- a/spec_cleaner/rpmprep.py
+++ b/spec_cleaner/rpmprep.py
@@ -4,7 +4,6 @@ from .rpmsection import Section
 
 
 class RpmPrep(Section):
-
     """
     A class providing methods for %prep section cleaning.
 

--- a/spec_cleaner/rpmprep.py
+++ b/spec_cleaner/rpmprep.py
@@ -60,6 +60,8 @@ class RpmPrep(Section):
         # this apply only if there is ONE -P on the line, not multiple ones
         match = self.reg.re_patch_prep.match(line)
         if match:
-            line = self.strip_useless_spaces('%%patch%s %s %s' % (match.group(2), match.group(1), match.group(3)))
+            line = self.strip_useless_spaces(
+                '%%patch%s %s %s' % (match.group(2), match.group(1), match.group(3))
+            )
 
         return line

--- a/spec_cleaner/rpmprune.py
+++ b/spec_cleaner/rpmprune.py
@@ -7,16 +7,14 @@ from .rpmsection import Section
 
 
 class RpmClean(Section):
-
     """Remove clean section."""
 
     def output(self, fout: IO[str], newline: bool = True, new_class_name: str = None) -> None:
-        """Do not output anything here"""
+        """Do not output anything here."""
         pass
 
 
 class RpmChangelog(Section):
-
     """Remove changelog entries."""
 
     def add(self, line: str) -> None:

--- a/spec_cleaner/rpmprune.py
+++ b/spec_cleaner/rpmprune.py
@@ -9,7 +9,9 @@ from .rpmsection import Section
 class RpmClean(Section):
     """Remove clean section."""
 
-    def output(self, fout: IO[str], newline: bool = True, new_class_name: str = None) -> None:
+    def output(
+        self, fout: IO[str], newline: bool = True, new_class_name: str = None
+    ) -> None:
         """Do not output anything here."""
         pass
 

--- a/spec_cleaner/rpmprune.py
+++ b/spec_cleaner/rpmprune.py
@@ -9,9 +9,7 @@ from .rpmsection import Section
 class RpmClean(Section):
     """Remove clean section."""
 
-    def output(
-        self, fout: IO[str], newline: bool = True, new_class_name: str = None
-    ) -> None:
+    def output(self, fout: IO[str], newline: bool = True, new_class_name: str = None) -> None:
         """Do not output anything here."""
         pass
 

--- a/spec_cleaner/rpmregexp.py
+++ b/spec_cleaner/rpmregexp.py
@@ -5,10 +5,10 @@ from typing import List
 
 
 class Regexp(object):
-
     """
-        Singleton containing all regular expressions compiled in one run.
-        So we can use them later everywhere without compiling them again,
+    Singleton containing all regular expressions compiled in one run.
+
+    So we can use them later everywhere without compiling them again.
     """
 
     # section macros

--- a/spec_cleaner/rpmregexp.py
+++ b/spec_cleaner/rpmregexp.py
@@ -57,9 +57,7 @@ class Regexp(object):
     re_source = re.compile(r'^Source(\d*):\s*(.*)', re.IGNORECASE)
     re_nosource = re.compile(r'^NoSource:\s*(.*)', re.IGNORECASE)
     re_patch = re.compile(r'^((?:#[#\s]*)?)Patch(\d*):\s*(\S*)', re.IGNORECASE)
-    re_buildrequires = re.compile(
-        r'^(BuildRequires|BuildPreReq):\s*(.*)', re.IGNORECASE
-    )
+    re_buildrequires = re.compile(r'^(BuildRequires|BuildPreReq):\s*(.*)', re.IGNORECASE)
     re_buildconflicts = re.compile(r'^BuildConflicts:\s*(.*)', re.IGNORECASE)
     re_buildignores = re.compile(r'^#!BuildIgnore:\s*(.*)', re.IGNORECASE)
     re_prereq = re.compile(r'^PreReq:\s*(.*)', re.IGNORECASE)
@@ -74,9 +72,7 @@ class Regexp(object):
     re_obsoletes = re.compile(r'^Obsoletes:\s*(.*)', re.IGNORECASE)
     re_buildroot = re.compile(r'^\s*BuildRoot:', re.IGNORECASE)
     re_buildarch = re.compile(r'^\s*BuildArch(itectures)?:\s*(.*)', re.IGNORECASE)
-    re_exclusivearch = re.compile(
-        r'^\s*ExclusiveArch(itectures)?:\s*(.*)', re.IGNORECASE
-    )
+    re_exclusivearch = re.compile(r'^\s*ExclusiveArch(itectures)?:\s*(.*)', re.IGNORECASE)
     re_excludearch = re.compile(r'^\s*ExcludeArch(itectures)?:\s*(.*)', re.IGNORECASE)
     re_epoch = re.compile(r'^\s*Epoch:\s*(.*)', re.IGNORECASE)
     re_icon = re.compile(r'^\s*Icon:\s*(.*)', re.IGNORECASE)
@@ -86,9 +82,7 @@ class Regexp(object):
     re_global = re.compile(r'^\s*%global\s*(.*)', re.IGNORECASE)
     re_bcond_with = re.compile(r'^\s*%bcond_with(out)?\s*(.*)', re.IGNORECASE)
     re_autoreqprov = re.compile(r'^\s*AutoReqProv:.*$', re.IGNORECASE)
-    re_debugpkg = re.compile(
-        r'^%{?(debug_package|___debug_install_post)}?\s*$', re.IGNORECASE
-    )
+    re_debugpkg = re.compile(r'^%{?(debug_package|___debug_install_post)}?\s*$', re.IGNORECASE)
     re_py_requires = re.compile(r'^%{?\??py_requires}?\s*$', re.IGNORECASE)
     re_mingw = re.compile(r'^\s*%{?_mingw.*$', re.IGNORECASE)
     re_patterndefine = re.compile(r'^\s*%{?pattern_\S+}?\s*$', re.IGNORECASE)
@@ -98,9 +92,7 @@ class Regexp(object):
     re_preamble_prefix = re.compile(r'^Prefix:\s*(.*)', re.IGNORECASE)
     # grab all macros with rpm call that query for version, this still might
     # be bit too greedy but it is good enough now
-    re_rpm_command = re.compile(
-        r'%\(\s*(rpm|echo\s+`rpm).*--queryformat\s+\'%{?VERSION}?\'.*\)'
-    )
+    re_rpm_command = re.compile(r'%\(\s*(rpm|echo\s+`rpm).*--queryformat\s+\'%{?VERSION}?\'.*\)')
     re_requires_eq = re.compile(r'^\s*(%{\?requires_eq:\s*)?%requires_eq\s*(.*)')
     re_requires_ge = re.compile(r'^\s*(%{\?requires_ge:\s*)?%requires_ge\s*(.*)')
     re_onelinecond = re.compile(r'^\s*%{!?[^?]*\?[^:]+:[^}]+}')
@@ -116,9 +108,7 @@ class Regexp(object):
     re_authors = re.compile(r'^\s*Author(s)?:\s*')
 
     # rpmbuild
-    re_jobs = re.compile(
-        r'%{?(_smp_mflags|\?_smp_flags|\?jobs:\s*-j\s*%(jobs|{jobs}))}?'
-    )
+    re_jobs = re.compile(r'%{?(_smp_mflags|\?_smp_flags|\?jobs:\s*-j\s*%(jobs|{jobs}))}?')
     re_make = re.compile(r'(^\s*)make(\s.*|)$')
     re_make_build = re.compile(r'(^\s*)%make_build(\s.*|)$')
     re_optflags_quotes = re.compile(r'=\s*\${?RPM_OPT_FLAGS}?\s*$')
@@ -159,9 +149,7 @@ class Regexp(object):
             r'(DESTDIR=%{buildroot}|%{\?_smp_mflags}|\s|V=1|VERBOSE=1|-j\d+)'
         )
     )
-    re_rm = re.compile(
-        r'rm\s+(-?\w?\ ?)*"?(%{buildroot}|\$b)"?/?"?%{_lib(dir)?}.*\*\.la;?$'
-    )
+    re_rm = re.compile(r'rm\s+(-?\w?\ ?)*"?(%{buildroot}|\$b)"?/?"?%{_lib(dir)?}.*\*\.la;?$')
     re_find = re.compile(
         r'find\s+"?(%{buildroot}|\$b)("?\S?/?)*\s*.*\s+-i?name\s+["\'\\]?\*\.la($|.*[^\\]$)'
     )
@@ -175,12 +163,8 @@ class Regexp(object):
     # rpmfiles
     re_man_compression = re.compile(r'(\d)(\.?\*|\.gz|%{?ext_man}?)$')
     re_info_compression = re.compile(r'\.info(\.?\*|\.gz|%{?ext_info}?)$')
-    re_defattr = re.compile(
-        r'^\s*%defattr\s*\(\s*-\s*,\s*root\s*,\s*root\s*(,\s*-\s*)?\)\s*'
-    )
-    re_doclicense = re.compile(
-        r'(\S+)?(LICEN(S|C)E|COPYING)(\*|\.(\*|\S+))?($|\s)', re.IGNORECASE
-    )
+    re_defattr = re.compile(r'^\s*%defattr\s*\(\s*-\s*,\s*root\s*,\s*root\s*(,\s*-\s*)?\)\s*')
+    re_doclicense = re.compile(r'(\S+)?(LICEN(S|C)E|COPYING)(\*|\.(\*|\S+))?($|\s)', re.IGNORECASE)
 
     # rpmscriptlets
     re_ldconfig = re.compile(r'(^|(.*\s)?)%{?run_ldconfig}?(\s.*|)$', re.IGNORECASE)

--- a/spec_cleaner/rpmregexp.py
+++ b/spec_cleaner/rpmregexp.py
@@ -32,11 +32,19 @@ class Regexp(object):
 
     # rpmpreamble
     # WARNING: keep in sync with rpmcleaner Section change detection
-    re_if = re.compile(r'^\s*(?:%{?if\s|%{?ifarch\s|%{?ifnarch\s|%{?if\S*}?(\s.*|)$)', re.IGNORECASE)
-    re_codeblock = re.compile(r'^\s*((### COMMON-([a-zA-Z0-9]+)-BEGIN ###|# MANUAL BEGIN|# SECTION)(\s.*|)|# MANUAL)$', re.IGNORECASE)
+    re_if = re.compile(
+        r'^\s*(?:%{?if\s|%{?ifarch\s|%{?ifnarch\s|%{?if\S*}?(\s.*|)$)', re.IGNORECASE
+    )
+    re_codeblock = re.compile(
+        r'^\s*((### COMMON-([a-zA-Z0-9]+)-BEGIN ###|# MANUAL BEGIN|# SECTION)(\s.*|)|# MANUAL)$',
+        re.IGNORECASE,
+    )
     re_else_elif = re.compile(r'^\s*%(else|elif)(\s.*|)$', re.IGNORECASE)
     re_endif = re.compile(r'^\s*%endif(\s.*|)$', re.IGNORECASE)
-    re_endcodeblock = re.compile(r'^\s*(### COMMON-([a-zA-Z0-9]+)-END ###|# MANUAL END|# /MANUAL|# (END|/)SECTION)(\s.*|)$', re.IGNORECASE)
+    re_endcodeblock = re.compile(
+        r'^\s*(### COMMON-([a-zA-Z0-9]+)-END ###|# MANUAL END|# /MANUAL|# (END|/)SECTION)(\s.*|)$',
+        re.IGNORECASE,
+    )
     re_name = re.compile(r'^Name:\s*(\S*)', re.IGNORECASE)
     re_version = re.compile(r'^Version:\s*(.*)', re.IGNORECASE)
     re_release = re.compile(r'^Release:\s*(\S*)', re.IGNORECASE)
@@ -49,7 +57,9 @@ class Regexp(object):
     re_source = re.compile(r'^Source(\d*):\s*(.*)', re.IGNORECASE)
     re_nosource = re.compile(r'^NoSource:\s*(.*)', re.IGNORECASE)
     re_patch = re.compile(r'^((?:#[#\s]*)?)Patch(\d*):\s*(\S*)', re.IGNORECASE)
-    re_buildrequires = re.compile(r'^(BuildRequires|BuildPreReq):\s*(.*)', re.IGNORECASE)
+    re_buildrequires = re.compile(
+        r'^(BuildRequires|BuildPreReq):\s*(.*)', re.IGNORECASE
+    )
     re_buildconflicts = re.compile(r'^BuildConflicts:\s*(.*)', re.IGNORECASE)
     re_buildignores = re.compile(r'^#!BuildIgnore:\s*(.*)', re.IGNORECASE)
     re_prereq = re.compile(r'^PreReq:\s*(.*)', re.IGNORECASE)
@@ -64,7 +74,9 @@ class Regexp(object):
     re_obsoletes = re.compile(r'^Obsoletes:\s*(.*)', re.IGNORECASE)
     re_buildroot = re.compile(r'^\s*BuildRoot:', re.IGNORECASE)
     re_buildarch = re.compile(r'^\s*BuildArch(itectures)?:\s*(.*)', re.IGNORECASE)
-    re_exclusivearch = re.compile(r'^\s*ExclusiveArch(itectures)?:\s*(.*)', re.IGNORECASE)
+    re_exclusivearch = re.compile(
+        r'^\s*ExclusiveArch(itectures)?:\s*(.*)', re.IGNORECASE
+    )
     re_excludearch = re.compile(r'^\s*ExcludeArch(itectures)?:\s*(.*)', re.IGNORECASE)
     re_epoch = re.compile(r'^\s*Epoch:\s*(.*)', re.IGNORECASE)
     re_icon = re.compile(r'^\s*Icon:\s*(.*)', re.IGNORECASE)
@@ -74,7 +86,9 @@ class Regexp(object):
     re_global = re.compile(r'^\s*%global\s*(.*)', re.IGNORECASE)
     re_bcond_with = re.compile(r'^\s*%bcond_with(out)?\s*(.*)', re.IGNORECASE)
     re_autoreqprov = re.compile(r'^\s*AutoReqProv:.*$', re.IGNORECASE)
-    re_debugpkg = re.compile(r'^%{?(debug_package|___debug_install_post)}?\s*$', re.IGNORECASE)
+    re_debugpkg = re.compile(
+        r'^%{?(debug_package|___debug_install_post)}?\s*$', re.IGNORECASE
+    )
     re_py_requires = re.compile(r'^%{?\??py_requires}?\s*$', re.IGNORECASE)
     re_mingw = re.compile(r'^\s*%{?_mingw.*$', re.IGNORECASE)
     re_patterndefine = re.compile(r'^\s*%{?pattern_\S+}?\s*$', re.IGNORECASE)
@@ -84,7 +98,9 @@ class Regexp(object):
     re_preamble_prefix = re.compile(r'^Prefix:\s*(.*)', re.IGNORECASE)
     # grab all macros with rpm call that query for version, this still might
     # be bit too greedy but it is good enough now
-    re_rpm_command = re.compile(r'%\(\s*(rpm|echo\s+`rpm).*--queryformat\s+\'%{?VERSION}?\'.*\)')
+    re_rpm_command = re.compile(
+        r'%\(\s*(rpm|echo\s+`rpm).*--queryformat\s+\'%{?VERSION}?\'.*\)'
+    )
     re_requires_eq = re.compile(r'^\s*(%{\?requires_eq:\s*)?%requires_eq\s*(.*)')
     re_requires_ge = re.compile(r'^\s*(%{\?requires_ge:\s*)?%requires_ge\s*(.*)')
     re_onelinecond = re.compile(r'^\s*%{!?[^?]*\?[^:]+:[^}]+}')
@@ -100,7 +116,9 @@ class Regexp(object):
     re_authors = re.compile(r'^\s*Author(s)?:\s*')
 
     # rpmbuild
-    re_jobs = re.compile(r'%{?(_smp_mflags|\?_smp_flags|\?jobs:\s*-j\s*%(jobs|{jobs}))}?')
+    re_jobs = re.compile(
+        r'%{?(_smp_mflags|\?_smp_flags|\?jobs:\s*-j\s*%(jobs|{jobs}))}?'
+    )
     re_make = re.compile(r'(^\s*)make(\s.*|)$')
     re_make_build = re.compile(r'(^\s*)%make_build(\s.*|)$')
     re_optflags_quotes = re.compile(r'=\s*\${?RPM_OPT_FLAGS}?\s*$')
@@ -110,14 +128,22 @@ class Regexp(object):
     re_cmake = re.compile(r'(^|(.*\s)?)cmake(\s.*|)$')
     re_qmake5 = re.compile(r'(^|(.*\s)?)qmake-qt5(\s.*|)$')
     re_meson = re.compile(r'(^|(.*\s)?)meson(\s.*|)$')
-    re_pytest = re.compile(r'%python_(expand|exec)\s+(PYTHONPATH=%{buildroot}%{\$?python_sitelib}\s+)?(\$?python\s+)?(%{_bindir}/?|-m\s+)?py\.?test(-(%{\$?python_version}|%{\$?python_bin_suffix})?)?(\s+(-v|-o addopts=-v))?')
-    re_pytest_arch = re.compile(r'%python_(expand|exec)\s+(PYTHONPATH=%{buildroot}%{\$?python_sitearch}\s+)?(\$?python\s+)?(%{_bindir}/?|-m\s+)?py\.?test(-(%{\$?python_version}|%{\$?python_bin_suffix})?)?(\s+(-v|-o addopts=-v))?')
-    re_python_expand = re.compile(r'%{?(python_sitelib|python_sitearch|python_bin_suffix|python_version)}?')
+    re_pytest = re.compile(
+        r'%python_(expand|exec)\s+(PYTHONPATH=%{buildroot}%{\$?python_sitelib}\s+)?(\$?python\s+)?(%{_bindir}/?|-m\s+)?py\.?test(-(%{\$?python_version}|%{\$?python_bin_suffix})?)?(\s+(-v|-o addopts=-v))?'
+    )
+    re_pytest_arch = re.compile(
+        r'%python_(expand|exec)\s+(PYTHONPATH=%{buildroot}%{\$?python_sitearch}\s+)?(\$?python\s+)?(%{_bindir}/?|-m\s+)?py\.?test(-(%{\$?python_version}|%{\$?python_bin_suffix})?)?(\s+(-v|-o addopts=-v))?'
+    )
+    re_python_expand = re.compile(
+        r'%{?(python_sitelib|python_sitearch|python_bin_suffix|python_version)}?'
+    )
     re_python_interp_expand = re.compile(r'\s+(python)\s+')
 
     # rpmcopyright
     re_copyright_string = re.compile(r'^#\s*Copyright\ \(c\)\s*(.*)', re.IGNORECASE)
-    re_suse_copyright = re.compile(r'SUSE (LLC\.?|LINUX (Products )?GmbH, Nuernberg, Germany\.)\s*$', re.IGNORECASE)
+    re_suse_copyright = re.compile(
+        r'SUSE (LLC\.?|LINUX (Products )?GmbH, Nuernberg, Germany\.)\s*$', re.IGNORECASE
+    )
     re_rootforbuild = re.compile(r'^#\s*needsrootforbuild\s*$', re.IGNORECASE)
     re_binariesforbuild = re.compile(r'^#\s*needsbinariesforbuild\s*$', re.IGNORECASE)
     re_nodebuginfo = re.compile(r'^#\s*nodebuginfo\s*$', re.IGNORECASE)
@@ -128,9 +154,17 @@ class Regexp(object):
 
     # rpminstall
     re_clean = re.compile(r'rm\s+(-?\w?\ ?)*"?(%{buildroot}|\$b)"?$')
-    re_install = re.compile(r'{0}*(%{{makeinstall}}|make{0}+install){0}*$'.format(r'(DESTDIR=%{buildroot}|%{\?_smp_mflags}|\s|V=1|VERBOSE=1|-j\d+)'))
-    re_rm = re.compile(r'rm\s+(-?\w?\ ?)*"?(%{buildroot}|\$b)"?/?"?%{_lib(dir)?}.*\*\.la;?$')
-    re_find = re.compile(r'find\s+"?(%{buildroot}|\$b)("?\S?/?)*\s*.*\s+-i?name\s+["\'\\]?\*\.la($|.*[^\\]$)')
+    re_install = re.compile(
+        r'{0}*(%{{makeinstall}}|make{0}+install){0}*$'.format(
+            r'(DESTDIR=%{buildroot}|%{\?_smp_mflags}|\s|V=1|VERBOSE=1|-j\d+)'
+        )
+    )
+    re_rm = re.compile(
+        r'rm\s+(-?\w?\ ?)*"?(%{buildroot}|\$b)"?/?"?%{_lib(dir)?}.*\*\.la;?$'
+    )
+    re_find = re.compile(
+        r'find\s+"?(%{buildroot}|\$b)("?\S?/?)*\s*.*\s+-i?name\s+["\'\\]?\*\.la($|.*[^\\]$)'
+    )
     re_find_double = re.compile(r'-i?name')
     re_rm_double = re.compile(r'(\.|{)a')
 
@@ -141,8 +175,12 @@ class Regexp(object):
     # rpmfiles
     re_man_compression = re.compile(r'(\d)(\.?\*|\.gz|%{?ext_man}?)$')
     re_info_compression = re.compile(r'\.info(\.?\*|\.gz|%{?ext_info}?)$')
-    re_defattr = re.compile(r'^\s*%defattr\s*\(\s*-\s*,\s*root\s*,\s*root\s*(,\s*-\s*)?\)\s*')
-    re_doclicense = re.compile(r'(\S+)?(LICEN(S|C)E|COPYING)(\*|\.(\*|\S+))?($|\s)', re.IGNORECASE)
+    re_defattr = re.compile(
+        r'^\s*%defattr\s*\(\s*-\s*,\s*root\s*,\s*root\s*(,\s*-\s*)?\)\s*'
+    )
+    re_doclicense = re.compile(
+        r'(\S+)?(LICEN(S|C)E|COPYING)(\*|\.(\*|\S+))?($|\s)', re.IGNORECASE
+    )
 
     # rpmscriptlets
     re_ldconfig = re.compile(r'(^|(.*\s)?)%{?run_ldconfig}?(\s.*|)$', re.IGNORECASE)

--- a/spec_cleaner/rpmrequirestoken.py
+++ b/spec_cleaner/rpmrequirestoken.py
@@ -78,7 +78,6 @@ class RpmRequiresToken(object):
         Raises:
             RpmException if prefix or name is not defined or the version is defined but no operator is present.
         """
-
         self.name = self._format_name(self.name)
         if not self.prefix:
             raise RpmException(

--- a/spec_cleaner/rpmrequirestoken.py
+++ b/spec_cleaner/rpmrequirestoken.py
@@ -19,8 +19,13 @@ class RpmRequiresToken(object):
 
     comments: Optional[str] = None
 
-    def __init__(self, name: str, operator: Optional[str] = None, version: Optional[str] = None,
-                 prefix: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        name: str,
+        operator: Optional[str] = None,
+        version: Optional[str] = None,
+        prefix: Optional[str] = None,
+    ) -> None:
         self.prefix = prefix
         self.name = name
         self.operator = operator

--- a/spec_cleaner/rpmscriplets.py
+++ b/spec_cleaner/rpmscriplets.py
@@ -29,9 +29,7 @@ class RpmScriptlets(Section):
         line = self.reg.re_ldconfig.sub('/sbin/ldconfig', line)
         return line
 
-    def output(
-        self, fout: IO[str], newline: bool = True, new_class_name: str = None
-    ) -> None:
+    def output(self, fout: IO[str], newline: bool = True, new_class_name: str = None) -> None:
         if not self.minimal:
             self._collapse_multiline_ldconfig()
         Section.output(self, fout, newline, new_class_name)

--- a/spec_cleaner/rpmscriplets.py
+++ b/spec_cleaner/rpmscriplets.py
@@ -29,7 +29,9 @@ class RpmScriptlets(Section):
         line = self.reg.re_ldconfig.sub('/sbin/ldconfig', line)
         return line
 
-    def output(self, fout: IO[str], newline: bool = True, new_class_name: str = None) -> None:
+    def output(
+        self, fout: IO[str], newline: bool = True, new_class_name: str = None
+    ) -> None:
         if not self.minimal:
             self._collapse_multiline_ldconfig()
         Section.output(self, fout, newline, new_class_name)

--- a/spec_cleaner/rpmscriplets.py
+++ b/spec_cleaner/rpmscriplets.py
@@ -5,7 +5,6 @@ from .rpmsection import Section
 
 
 class RpmScriptlets(Section):
-
     """
     A class providing methods for scriptlet section cleaning.
 
@@ -37,7 +36,9 @@ class RpmScriptlets(Section):
 
     def _collapse_multiline_ldconfig(self) -> None:
         """
-        Merge two lines ldconfig call to the one line and adjust lines member accordingly.
+        Merge two lines ldconfig call to the one line.
+
+        Adjust lines member accordingly.
         """
         # if we have 2 lines or rest of them are empty, pop those
         for i in reversed(self.lines):

--- a/spec_cleaner/rpmsection.py
+++ b/spec_cleaner/rpmsection.py
@@ -102,7 +102,9 @@ class Section(object):
         self.lines.append(line)
         self.previous_line = line
 
-    def output(self, fout: IO[str], newline: bool = True, new_class_name: str = None) -> None:
+    def output(
+        self, fout: IO[str], newline: bool = True, new_class_name: str = None
+    ) -> None:
         """
         Manage printing of the section.
 
@@ -125,11 +127,16 @@ class Section(object):
                 and not self.lines[-1].endswith('\\')
             ):
                 self.lines.append('')
-            if new_class_name != 'RpmScriptlets' and (self.lines[-1].startswith('%pre') or self.lines[-1].startswith('%post')):
+            if new_class_name != 'RpmScriptlets' and (
+                self.lines[-1].startswith('%pre') or self.lines[-1].startswith('%post')
+            ):
                 self.lines.append('')
             # remove the newlines around ifs if they are not wanted
             if len(self.lines) >= 2:
-                if self.lines[-1] == '' and (self.lines[-2].startswith('%if') or self.lines[-2].startswith('%else')):
+                if self.lines[-1] == '' and (
+                    self.lines[-2].startswith('%if')
+                    or self.lines[-2].startswith('%else')
+                ):
                     self.lines.pop()
 
         for line in self.lines:
@@ -353,8 +360,20 @@ class Section(object):
         Returns:
             The line with formatted version conditions.
         """
-        for i in ['centos', 'debian', 'fedora', 'mandriva', 'meego', 'rhel', 'sles', 'suse', 'ubuntu']:
-            line = line.replace('%{' + i + '_version}', '0%{?' + i + '_version}').replace('00%{', '0%{')
+        for i in [
+            'centos',
+            'debian',
+            'fedora',
+            'mandriva',
+            'meego',
+            'rhel',
+            'sles',
+            'suse',
+            'ubuntu',
+        ]:
+            line = line.replace(
+                '%{' + i + '_version}', '0%{?' + i + '_version}'
+            ).replace('00%{', '0%{')
         return line
 
     def replace_preamble_macros(self, line: str) -> str:

--- a/spec_cleaner/rpmsection.py
+++ b/spec_cleaner/rpmsection.py
@@ -102,9 +102,7 @@ class Section(object):
         self.lines.append(line)
         self.previous_line = line
 
-    def output(
-        self, fout: IO[str], newline: bool = True, new_class_name: str = None
-    ) -> None:
+    def output(self, fout: IO[str], newline: bool = True, new_class_name: str = None) -> None:
         """
         Manage printing of the section.
 
@@ -134,8 +132,7 @@ class Section(object):
             # remove the newlines around ifs if they are not wanted
             if len(self.lines) >= 2:
                 if self.lines[-1] == '' and (
-                    self.lines[-2].startswith('%if')
-                    or self.lines[-2].startswith('%else')
+                    self.lines[-2].startswith('%if') or self.lines[-2].startswith('%else')
                 ):
                     self.lines.pop()
 
@@ -371,9 +368,9 @@ class Section(object):
             'suse',
             'ubuntu',
         ]:
-            line = line.replace(
-                '%{' + i + '_version}', '0%{?' + i + '_version}'
-            ).replace('00%{', '0%{')
+            line = line.replace('%{' + i + '_version}', '0%{?' + i + '_version}').replace(
+                '00%{', '0%{'
+            )
         return line
 
     def replace_preamble_macros(self, line: str) -> str:

--- a/spec_cleaner/rpmsection.py
+++ b/spec_cleaner/rpmsection.py
@@ -5,7 +5,6 @@ from .rpmregexp import Regexp
 
 
 class Section(object):
-
     """
     Basic object for parsing each section of spec file.
 
@@ -40,9 +39,10 @@ class Section(object):
 
     def _complete_cleanup(self, line: str) -> str:
         """
-        Call all the cleanups in proper order so it
-        can be called beforehand if we override add phase and want to
-        do our replaces after cleanup.
+        Call all the cleanups in proper order.
+
+        Therefore it can be called beforehand if we override add phase and want to do
+        our replaces after cleanup.
 
         Args:
             line: A string representing a line to process.
@@ -153,8 +153,7 @@ class Section(object):
 
     def embrace_macros(self, line: str) -> str:
         """
-        Add {} around known macros that have no arguments and are not
-        on whitelist.
+        Add {} around known macros that have no arguments and are not on whitelist.
 
         Whitelist is passed from caller object.
 


### PR DESCRIPTION
Use pre-commit tool for managing pre-commit git hook that will run black, flake8 and mypy checks before every commit.

**pre-commit**
Every contributor has to install the pre-commit tool and then run `pre-commit install` for installing pre-commit hook to his/her git hooks.

Then pre-commit will run automatically on git commit and it will check the changed files with black, flake8, flake8-docstrings and mypy.

**black**
The whole project was formated with black. pre-commit now will format all the new code in the pre-commit hook. If the code is needed to be formated, black formats the code and the check fails. So you have a chance to see the changes and commit again.

**flake8-docstrings**
Currently, there is a lot of methods without docstrings. Since it checks all files involved in the commit, it may throw docstrings errors for the code that wasn't touched. Then it would be nice of you to help and add missing docstrings to make pre-commit happy. This is just a temporary problem because at some point I believe all methods will have their docstrings :)

**Coding Guidelines**
In this PR I suggest enforcing Coding Guidelines (see README.md) during the code reviews and not accepting changes that don't meet it (mainly for docstrings for "non-public" methods that are not checked with flake8-docstrings extension).