### PR TITLE
recognize unittest calls

### DIFF
--- a/data/excludes-bracketing.txt
+++ b/data/excludes-bracketing.txt
@@ -134,6 +134,8 @@ pypy(.?)_only
 pycache_only
 pytest
 pytest_arch
+pyunittest
+pyunittest_arch
 python(.?)_build
 python(.?)_install
 py(.?)_build

--- a/spec_cleaner/rpmcheck.py
+++ b/spec_cleaner/rpmcheck.py
@@ -18,6 +18,7 @@ class RpmCheck(Section):
 
         if not self.minimal:
             line = self._replace_pytest(line)
+            line = self._replace_unittest(line)
             line = self._replace_make(line)
 
         Section.add(self, line)
@@ -34,6 +35,20 @@ class RpmCheck(Section):
         """
         line = self.reg.re_pytest.sub('%pytest', line)
         line = self.reg.re_pytest_arch.sub('%pytest_arch', line)
+        return line
+
+    def _replace_unittest(self, line: str) -> str:
+        """
+        Replace various pytest calls with %pyunittest or %pyunittest_arch macros.
+
+        Args:
+            line: A string representing a line to process.
+
+        Return:
+            The processed line.
+        """
+        line = self.reg.re_pyunittest.sub('%pyunittest', line)
+        line = self.reg.re_pyunittest_arch.sub('%pyunittest_arch', line)
         return line
 
     def _replace_make(self, line: str) -> str:

--- a/spec_cleaner/rpmregexp.py
+++ b/spec_cleaner/rpmregexp.py
@@ -126,6 +126,12 @@ class Regexp(object):
     re_pytest_arch = re.compile(
         r'%python_(expand|exec)\s+(PYTHONPATH=%{buildroot}%{\$?python_sitearch}\s+)?(\$?python\s+)?(%{_bindir}/?|-m\s+)?py\.?test(-(%{\$?python_version}|%{\$?python_bin_suffix})?)?(\s+(-v|-o addopts=-v))?'
     )
+    re_pyunittest = re.compile(
+        r'%python_(expand|exec)\s+(PYTHONPATH=%{buildroot}%{\$?python_sitelib}\s+)?(\$?python\s+)?-m\s+unittest(\s+discover)?'
+    )
+    re_pyunittest_arch = re.compile(
+        r'%python_(expand|exec)\s+(PYTHONPATH=%{buildroot}%{\$?python_sitearch}\s+)?(\$?python\s+)?-m\s+unittest(\s+discover)?'
+    )
     re_python_expand = re.compile(
         r'%{?(python_sitelib|python_sitearch|python_bin_suffix|python_version)}?'
     )

--- a/tests/in/pyunittest.spec
+++ b/tests/in/pyunittest.spec
@@ -1,0 +1,9 @@
+%check
+%python_expand PYTHONPATH=%{buildroot}%{$python_sitelib} $python -m unittest discover
+%python_expand PYTHONPATH=%{buildroot}%{$python_sitelib} $python -m unittest discover -v
+%python_exec -m unittest discover tests -v
+%python_exec -m unittest discover
+%python_exec -m unittest discover -v -s tests
+%python_exec -m unittest -v tests.test_cursors
+%python_expand PYTHONPATH=%{buildroot}%{$python_sitelib} $python -m unittest openid.test.test_suite
+%python_expand PYTHONPATH=%{buildroot}%{$python_sitearch} $python -m unittest discover -v

--- a/tests/out-minimal/pyunittest.spec
+++ b/tests/out-minimal/pyunittest.spec
@@ -1,0 +1,11 @@
+%check
+%python_expand PYTHONPATH=%{buildroot}%{$python_sitelib} $python -m unittest discover
+%python_expand PYTHONPATH=%{buildroot}%{$python_sitelib} $python -m unittest discover -v
+%python_exec -m unittest discover tests -v
+%python_exec -m unittest discover
+%python_exec -m unittest discover -v -s tests
+%python_exec -m unittest -v tests.test_cursors
+%python_expand PYTHONPATH=%{buildroot}%{$python_sitelib} $python -m unittest openid.test.test_suite
+%python_expand PYTHONPATH=%{buildroot}%{$python_sitearch} $python -m unittest discover -v
+
+%changelog

--- a/tests/out/pyunittest.spec
+++ b/tests/out/pyunittest.spec
@@ -1,0 +1,11 @@
+%check
+%pyunittest
+%pyunittest -v
+%pyunittest tests -v
+%pyunittest
+%pyunittest -v -s tests
+%pyunittest -v tests.test_cursors
+%pyunittest openid.test.test_suite
+%pyunittest_arch -v
+
+%changelog


### PR DESCRIPTION
There are new macros %pyunittest and %pyunittest_arch in python-rpm-macros. Recognize the calls in *spec files.

It should break only few things, if any.