### PR TITLE
Fix #287: Incorrect curlification for more systemd-macros

### DIFF
--- a/data/excludes-bracketing.txt
+++ b/data/excludes-bracketing.txt
@@ -161,6 +161,8 @@ suse_update_desktop_file
 systemd_ordering
 systemd_preun
 systemd_requires
+systemd_user_post
+systemd_user_prerun
 sysusers_create
 sysusers_requires
 sysusers_generate_pre


### PR DESCRIPTION
This is untested, but I figured from https://github.com/rpm-software-management/spec-cleaner/issues/67 that the fix should look like that.