### PR TITLE
Add new head category for PSP macros

### DIFF
--- a/spec_cleaner/rpmpreamble.py
+++ b/spec_cleaner/rpmpreamble.py
@@ -115,6 +115,7 @@ class RpmPreamble(Section):
             'excludearch': self.reg.re_excludearch,
             'exclusivearch': self.reg.re_exclusivearch,
             'tail': self.reg.re_tail_macros,
+            'head': self.reg.re_head_macros,
         }
 
         # deprecated definitions that we no longer want to see
@@ -692,6 +693,9 @@ class RpmPreamble(Section):
                 self._add_line_value_to('buildarch', value)
             else:
                 self._add_line_value_to('exclusivearch', value)
+
+        elif self.reg.re_head_macros.match(line):
+            self._add_line_value_to('head', line)
 
         # loop for all other matching categories which
         # do not require special attention

--- a/spec_cleaner/rpmpreambleelements.py
+++ b/spec_cleaner/rpmpreambleelements.py
@@ -54,6 +54,7 @@ class RpmPreambleElements(object):
         'define',
         'bconds',
         'bcond_conditions',
+        'head',
         'name',
         'version',
         'release',
@@ -307,6 +308,8 @@ class RpmPreambleElements(object):
         keylen = len('BuildRequires:  ')
 
         if category == 'tail':
+            return ''
+        if category == 'head':
             return ''
         elif key:
             pass

--- a/spec_cleaner/rpmregexp.py
+++ b/spec_cleaner/rpmregexp.py
@@ -90,6 +90,7 @@ class Regexp(object):
     re_patternmacro = re.compile(r'pattern(-\S+)?\(\)', re.IGNORECASE)
     re_patternobsolete = re.compile(r'patterns-openSUSE-\S+', re.IGNORECASE)
     re_tail_macros = re.compile(r'^%{?python_subpackages}?')
+    re_head_macros = re.compile(r'^%{?\??(sle15_python_module_pythons|sle15allpythons)}?')
     re_preamble_prefix = re.compile(r'^Prefix:\s*(.*)', re.IGNORECASE)
     # grab all macros with rpm call that query for version, this still might
     # be bit too greedy but it is good enough now

--- a/tests/in/psp-macro-all.spec
+++ b/tests/in/psp-macro-all.spec
@@ -1,0 +1,31 @@
+#
+# spec file
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%{?sle15allpythons}
+Name:           python-munch
+Version:        3.0.0
+Release:        0
+BuildRequires:  python-rpm-macros
+Requires:       python-six
+BuildArch:      noarch
+# SECTION test requirements
+BuildRequires:  %{python_module pytest}
+BuildRequires:  %{python_module six}
+
+%changelog
+

--- a/tests/in/psp-macro.spec
+++ b/tests/in/psp-macro.spec
@@ -1,0 +1,30 @@
+#
+# spec file
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%{?sle15_python_module_pythons}
+Name:           python-munch
+Version:        3.0.0
+Release:        0
+BuildRequires:  python-rpm-macros
+Requires:       python-six
+BuildArch:      noarch
+# SECTION test requirements
+BuildRequires:  %{python_module pytest}
+BuildRequires:  %{python_module six}
+
+%changelog

--- a/tests/out/psp-macro-all.spec
+++ b/tests/out/psp-macro-all.spec
@@ -1,0 +1,30 @@
+#
+# spec file
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%{?sle15allpythons}
+Name:           python-munch
+Version:        3.0.0
+Release:        0
+BuildRequires:  python-rpm-macros
+Requires:       python-six
+BuildArch:      noarch
+# SECTION test requirements
+BuildRequires:  %{python_module pytest}
+BuildRequires:  %{python_module six}
+
+%changelog

--- a/tests/out/psp-macro.spec
+++ b/tests/out/psp-macro.spec
@@ -1,0 +1,30 @@
+#
+# spec file
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%{?sle15_python_module_pythons}
+Name:           python-munch
+Version:        3.0.0
+Release:        0
+BuildRequires:  python-rpm-macros
+Requires:       python-six
+BuildArch:      noarch
+# SECTION test requirements
+BuildRequires:  %{python_module pytest}
+BuildRequires:  %{python_module six}
+
+%changelog


### PR DESCRIPTION
This patch adds a new category "head", similar to the "tail" category, to match the modern python macros for SUSE SLE
(sle15_python_module_pythons and sle15allpythons), these macros changed the "pythons" definition, so they should go before any usage of the python-rpm-macros.

Fix https://github.com/rpm-software-management/spec-cleaner/issues/308