### PR TITLE
Expand python sitelib glob usage in files

### DIFF
--- a/spec_cleaner/rpmregexp.py
+++ b/spec_cleaner/rpmregexp.py
@@ -176,6 +176,9 @@ class Regexp(object):
     re_info_compression = re.compile(r'\.info(\.?\*|\.gz|%{?ext_info}?)$')
     re_defattr = re.compile(r'^\s*%defattr\s*\(\s*-\s*,\s*root\s*,\s*root\s*(,\s*-\s*)?\)\s*')
     re_doclicense = re.compile(r'(\S+)?(LICEN(S|C)E|COPYING)(\*|\.(\*|\S+))?($|\s)', re.IGNORECASE)
+    # python sitelib
+    re_python_sitelib_glob = re.compile(r'^(?P<macro>%{(python\d*)_(sitelib|sitearch)})/\*$')
+    re_python_package_name = re.compile(r'^python\d*-(.*)')
 
     # rpmscriptlets
     re_ldconfig = re.compile(r'(^|(.*\s)?)%{?run_ldconfig}?(\s.*|)$', re.IGNORECASE)

--- a/tests/in/python-sitelib.spec
+++ b/tests/in/python-sitelib.spec
@@ -1,0 +1,26 @@
+#
+# spec file for package python-sitelib
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%files
+%license COPYING
+%doc ChangeLog README
+%{python_sitelib}/*
+%{python_sitearch}/*
+%{python3_sitearch}/*
+
+%changelog

--- a/tests/in/sitelib-python.spec
+++ b/tests/in/sitelib-python.spec
@@ -1,0 +1,26 @@
+#
+# spec file for package python-sitelib
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%files
+%license COPYING
+%doc ChangeLog README
+%{python_sitelib}/*
+%{python_sitearch}/*
+%{python3_sitearch}/*
+
+%changelog

--- a/tests/out/python-sitelib.spec
+++ b/tests/out/python-sitelib.spec
@@ -1,0 +1,29 @@
+#
+# spec file for package python-sitelib
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%files
+%license COPYING
+%doc ChangeLog README
+%{python_sitelib}/sitelib
+%{python_sitelib}/sitelib-%{version}*-info
+%{python_sitearch}/sitelib
+%{python_sitearch}/sitelib-%{version}*-info
+%{python3_sitearch}/sitelib
+%{python3_sitearch}/sitelib-%{version}*-info
+
+%changelog

--- a/tests/out/sitelib-python.spec
+++ b/tests/out/sitelib-python.spec
@@ -1,0 +1,29 @@
+#
+# spec file for package python-sitelib
+#
+# Copyright (c) 2023 SUSE LLC
+#
+# All modifications and additions to the file contributed by third parties
+# remain the property of their copyright owners, unless otherwise agreed
+# upon. The license for this file, and modifications and additions to the
+# file, is the same license as for the pristine package itself (unless the
+# license for the pristine package is not an Open Source License, in which
+# case the license is the MIT License). An "Open Source License" is a
+# license that conforms to the Open Source Definition (Version 1.9)
+# published by the Open Source Initiative.
+
+# Please submit bugfixes or comments via https://bugs.opensuse.org/
+#
+
+
+%files
+%license COPYING
+%doc ChangeLog README
+%{python_sitelib}/sitelib-python
+%{python_sitelib}/sitelib-python-%{version}*-info
+%{python_sitearch}/sitelib-python
+%{python_sitearch}/sitelib-python-%{version}*-info
+%{python3_sitearch}/sitelib-python
+%{python3_sitearch}/sitelib-python-%{version}*-info
+
+%changelog


### PR DESCRIPTION
This patch expand the "%{python_sitelib}/*" usage in files to something more especific:

%{python_sitelib}/packagename
%{python_sitelib}/packagename-%{version}*-info

Fix https://github.com/rpm-software-management/spec-cleaner/issues/312