### PR TITLE
Add missing groups from openSUSE:Package_group_guidelines

### DIFF
--- a/data/allowed_groups.txt
+++ b/data/allowed_groups.txt
@@ -29,8 +29,12 @@ Amusements/Toys/Other
 Amusements/Toys/Screensavers
 Development/Languages/C and C++
 Development/Languages/Fortran
+Development/Languages/Go
 Development/Languages/Haskell
 Development/Languages/Java
+Development/Languages/Lua
+Development/Languages/NodeJS
+Development/Languages/OCaml
 Development/Languages/Other
 Development/Languages/Perl
 Development/Languages/PHP


### PR DESCRIPTION
The list of allowed package groups is outdated with respect to [openSUSE:Package_group_guidelines](https://en.opensuse.org/openSUSE:Package_group_guidelines), so I sent this PR updating them.

> NOTE: To generate the changes in this PR, I executed the following commands:
>
> ```shell
> cd spec-cleaner/data
> echo '# Taken from https://en.opensuse.org/openSUSE:Package_group_guidelines' > allowed_groups.txt
> curl -s https://en.opensuse.org/openSUSE:Package_group_guidelines | grep -Eo '^[^ ]+<tt>.*</tt>' | sed -E -e 's/^[^ ]+<tt>//g' -e 's/<\/tt>.*//g' >> allowed_groups.txt
> ```

Fixes #317