### PR TITLE
Update rpmprep to handle %patchN for rpm >= 4.20

### DIFF
--- a/spec_cleaner/rpmprep.py
+++ b/spec_cleaner/rpmprep.py
@@ -58,7 +58,7 @@ class RpmPrep(Section):
         """
         Convert patchlines to something pretty.
 
-        E.g. it converts "%patch -P 50 -p10" to "%patch50 -p10" and so on.
+        E.g. it converts "%patch50 -p10" to "%patch -P 50 -p10" and so on.
 
         Args:
             line: A string representing a line to process.
@@ -69,16 +69,15 @@ class RpmPrep(Section):
         # -p0 is default
         if line.startswith('%patch'):
             line = line.replace('-p0', '')
-        # %patch0 is desired
+        # %patch without -P was %patch0 before, convert to %patch0 for the reges
         if (line.startswith('%patch ') or line == '%patch') and '-P' not in line:
             line = line.replace('%patch', '%patch0')
 
-        # convert the %patch -P 50 -p10 to %patch50 -p10
-        # this apply only if there is ONE -P on the line, not multiple ones
+        # convert the %patch50 -p10 to %patch -P 50 -p10
         match = self.reg.re_patch_prep.match(line)
         if match:
             line = self.strip_useless_spaces(
-                '%%patch%s %s %s' % (match.group(2), match.group(1), match.group(3))
+                '%%patch -P %s %s' % (match.group(1), match.group(2))
             )
 
         return line

--- a/spec_cleaner/rpmregexp.py
+++ b/spec_cleaner/rpmregexp.py
@@ -167,7 +167,7 @@ class Regexp(object):
     re_rm_double = re.compile(r'(\.|{)a')
 
     # rpmprep
-    re_patch_prep = re.compile(r'^%patch\s*([^P]*)-P\s*(\d*)\s*([^P]*)$')
+    re_patch_prep = re.compile(r'^%patch(\d+)\s*(.*)$')
     re_setup = re.compile(r'\s*-n\s+"?%{name}-%{version}"?($|\s)')
     re_dephell_setup = re.compile(r'\s*dephell[s]?.*convert')
 

--- a/tests/out/mingw32-clutter.spec
+++ b/tests/out/mingw32-clutter.spec
@@ -92,8 +92,8 @@ files for development.
 %prep
 %setup -q -n clutter-%{version}
 
-%patch0 -p1 -b .windows
-%patch1 -p1 -b .ldl
+%patch -P 0 -p1 -b .windows
+%patch -P 1 -p1 -b .ldl
 
 %build
 libtoolize --force --copy --install

--- a/tests/out/patches.spec
+++ b/tests/out/patches.spec
@@ -10,16 +10,16 @@ Patch12:        i
 Patch99:        f
 
 %prep
-%patch3 -p1
-%patch2
-%patch99 -p1
-%patch0 -p1
-%patch1
-%patch0 -p1
-%patch10
-%patch11 -p1
-%patch12
-%patch11 -p3
+%patch -P 3 -p1
+%patch -P 2
+%patch -P 99 -p1
+%patch -P 0 -p1
+%patch -P 1
+%patch -P 0 -p1
+%patch -P 10
+%patch -p1  -P 	11
+%patch  -P12
+%patch -P11 -p3
 %patch -P20 -P30
 
 %changelog

--- a/tests/out/rpmpreamble.spec
+++ b/tests/out/rpmpreamble.spec
@@ -90,8 +90,8 @@ Headers, pkg-config files, so link and other development files for %{name}
 
 %prep
 %setup -q
-%patch1
-%patch2
+%patch -P 1
+%patch -P 2
 
 %build
 %configure \

--- a/tests/out/sourcespatches.spec
+++ b/tests/out/sourcespatches.spec
@@ -21,7 +21,7 @@ Patch10:        test2
 %setup -q -a1
 %setup -q -b2
 %setup -q -n %{name}-%{version}-src
-%patch10 -p4
-%patch0 -p1
+%patch -P 10 -p4
+%patch -P 0 -p1
 
 %changelog


### PR DESCRIPTION
The usage of %patchN is not supported by RPM >= 4.20. The preferred way to apply patches are, in order:
 * %autosetup -p1
 * %autosetup -N / %autopatch -p1
 * %setup / %patch -P <N> -p 1

This patch changes the usage of "%patchN" with the new format "%patch -P N"

Thanks to Stefan Seyfried (@seife) for the initial patch.

Fix https://github.com/rpm-software-management/spec-cleaner/issues/319