### PR TITLE
Use python-rpm-spec instead of calling rpmspec command

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: ["3.6", "3.7", "3.8", "3.9"]
+        python-version: ["3.6", "3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/devel-requirements.pip
+++ b/devel-requirements.pip
@@ -14,3 +14,4 @@ pytest
 pytest-cov
 pytest-isort
 pytest-xdist
+python-rpm-spec

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     platforms=['Linux'],
     keywords=['SUSE', 'RPM', '.spec', 'cleaner'],
     tests_require=['pytest', 'pytest-cov', 'pytest-xdist'],
+    install_requires=['python-rpm-spec'],
     packages=['spec_cleaner'],
     data_files=[('lib/obs/service/', glob('obs/*')), ('share/spec-cleaner', glob('data/*'))],
     entry_points={'console_scripts': ['spec-cleaner = spec_cleaner:main']},

--- a/spec_cleaner/rpmpreamble.py
+++ b/spec_cleaner/rpmpreamble.py
@@ -7,7 +7,7 @@ from ssl import CertificateError, SSLError
 from urllib import error, parse
 from urllib.request import Request, urlopen
 
-import pyrpm.spec
+import pyrpm.spec  # type: ignore
 
 from .dependency_parser import DependencyParser
 from .rpmhelpers import fix_license

--- a/tests/in/source_https.spec
+++ b/tests/in/source_https.spec
@@ -1,0 +1,24 @@
+%define         tarname    Python-%{version}
+%define         folderversion %{version}
+Name:           python311
+Version:        3.11.8
+Summary:        Replace http with https if possible
+License:        GPL-2.0
+Source0:        http://www.python.org/ftp/python/%{folderversion}/%{tarname}.tar.xz
+Source1:        http://www.python.org/ftp/python/%{folderversion}/%{tarname}.tar.xz.asc
+Source3:        http://google.com
+Source4:        https://google.com
+Source5:        www.google.com
+Source6:        google.com
+# non existent
+Source7:        http://thishopefullydoesnexist.com
+# Certificate
+Source8:        http://expired.badssl.com/
+Source9:        http://wrong.host.badssl.com/
+Source10:       http://null.badssl.com/
+# URL is FTP (issue#258)
+Source11:       ftp://ftp.null.badssl.com/
+Source12:       ftp.null.badssl.com/
+# other prefix
+Source13:       abc://null.badssl.com/
+Source14:       http://xavprods.free.fr/lzx

--- a/tests/out/mingw32-clutter.spec
+++ b/tests/out/mingw32-clutter.spec
@@ -25,7 +25,7 @@ License:        LGPL-2.1-or-later
 # FIXME: use correct group or remove it, see "https://en.opensuse.org/openSUSE:Package_group_guidelines"
 Group:          Development/Libraries
 URL:            https://clutter-project.org/
-Source:         http://www.clutter-project.org/sources/clutter/1.5/clutter-%{version}.tar.bz2
+Source:         https://www.clutter-project.org/sources/clutter/1.5/clutter-%{version}.tar.bz2
 Patch0:         clutter-1.6.14-windows.patch
 Patch1:         clutter-1.6.20-ldl.patch
 # Native version for glib-genmarshal

--- a/tests/out/replace_pwdutils.spec
+++ b/tests/out/replace_pwdutils.spec
@@ -5,7 +5,7 @@ Summary:        A Job Manager
 License:        GPL-2.0-or-later
 Group:          System/Daemons
 URL:            https://ftp.debian.org/debian/pool/main/a/at
-Source:         http://ftp.debian.org/debian/pool/main/a/at/%{name}_%{version}.orig.tar.gz
+Source:         https://ftp.debian.org/debian/pool/main/a/at/%{name}_%{version}.orig.tar.gz
 BuildRequires:  autoconf >= 2.69
 BuildRequires:  automake
 BuildRequires:  pam-devel

--- a/tests/out/source_https.spec
+++ b/tests/out/source_https.spec
@@ -1,0 +1,26 @@
+%define         tarname    Python-%{version}
+%define         folderversion %{version}
+Name:           python311
+Version:        3.11.8
+Summary:        Replace http with https if possible
+License:        GPL-2.0-only
+Source0:        https://www.python.org/ftp/python/%{folderversion}/%{tarname}.tar.xz
+Source1:        https://www.python.org/ftp/python/%{folderversion}/%{tarname}.tar.xz.asc
+Source3:        https://google.com
+Source4:        https://google.com
+Source5:        www.google.com
+Source6:        google.com
+# non existent
+Source7:        http://thishopefullydoesnexist.com
+# Certificate
+Source8:        http://expired.badssl.com/
+Source9:        http://wrong.host.badssl.com/
+Source10:       http://null.badssl.com/
+# URL is FTP (issue#258)
+Source11:       ftp://ftp.null.badssl.com/
+Source12:       ftp.null.badssl.com/
+# other prefix
+Source13:       abc://null.badssl.com/
+Source14:       http://xavprods.free.fr/lzx
+
+%changelog


### PR DESCRIPTION
This patch replaces the call to rpmspec binary with the usage of the python library python-rpm-spec. The usage of this module adds it as a dependency.

Fix https://github.com/rpm-software-management/spec-cleaner/issues/304