### PR TITLE
Do not modify copyright by default

### DIFF
--- a/spec_cleaner/__init__.py
+++ b/spec_cleaner/__init__.py
@@ -81,7 +81,12 @@ def process_args(argv: List[str]) -> Dict[str, Any]:
     parser.add_argument(
         '--no-copyright',
         action='store_true',
-        help='do not include official SUSE copyright hear and just keep what is present',
+        help='does nothing, existing option to keep compatibility with older versions, use --suse-copyright to modify the copyright header.',
+    )
+    parser.add_argument(
+        '--suse-copyright',
+        action='store_true',
+        help='Include official SUSE copyright',
     )
     parser.add_argument(
         '--remove-groups', action='store_true', help='remove groups from the specfile.'

--- a/spec_cleaner/rpmcopyright.py
+++ b/spec_cleaner/rpmcopyright.py
@@ -18,7 +18,7 @@ class RpmCopyright(Section):
     def __init__(self, options):
         """Initialize default variables."""
         Section.__init__(self, options)
-        self.no_copyright = options['no_copyright']
+        self.suse_copyright = options['suse_copyright']
         self.year = options['copyright_year']
         self.copyrights = []
         self.buildrules = []
@@ -76,7 +76,7 @@ class RpmCopyright(Section):
         If we have no copyright header we actually should not touch it not
         wipe out, thus just add everything to known lines
         """
-        if self.no_copyright:
+        if not self.suse_copyright:
             self.lines.append(line)
             return
         if not self.lines and not line:
@@ -104,7 +104,7 @@ class RpmCopyright(Section):
 
     def output(self, fout: IO[str], newline: bool = True, new_class_name: str = ''):
         """Manage printing of the Copyright section."""
-        if not self.no_copyright:
+        if self.suse_copyright:
             self._add_modelines()
             self._add_pkg_header()
             self._add_copyright()

--- a/tests/acceptance-tests.py
+++ b/tests/acceptance-tests.py
@@ -52,7 +52,7 @@ class TestCompare(object):
         'diff_prog': 'vimdiff',
         'minimal': False,
         'no_curlification': False,
-        'no_copyright': True,
+        'suse_copyright': False,
         'copyright_year': 2013,
         'remove_groups': False,
         'tex': False,
@@ -140,7 +140,7 @@ class TestCompare(object):
     @pytest.mark.parametrize(
         'test, compare_dir, options',
         [
-            ('header.spec', 'header', {'minimal': True, 'no_copyright': False}),
+            ('header.spec', 'header', {'minimal': True, 'suse_copyright': True}),
             ('pkgconfrequires.spec', 'out', {'pkgconfig': False}),
             ('tex.spec', 'tex', {'tex': True}),
             ('perl.spec', 'perl', {'perl': True}),

--- a/tests/out/mingw32-clutter.spec
+++ b/tests/out/mingw32-clutter.spec
@@ -25,7 +25,7 @@ License:        LGPL-2.1-or-later
 # FIXME: use correct group or remove it, see "https://en.opensuse.org/openSUSE:Package_group_guidelines"
 Group:          Development/Libraries
 URL:            https://clutter-project.org/
-Source:         https://www.clutter-project.org/sources/clutter/1.5/clutter-%{version}.tar.bz2
+Source:         http://www.clutter-project.org/sources/clutter/1.5/clutter-%{version}.tar.bz2
 Patch0:         clutter-1.6.14-windows.patch
 Patch1:         clutter-1.6.20-ldl.patch
 # Native version for glib-genmarshal


### PR DESCRIPTION
This patch changes the option --no-copyright to --suse-copyright and it's False by default. So by default the spec-cleaner tool won't modify the copyright header, from now on it can be done with the new --suse-copyright command line argument.

See mailing list thread
https://lists.opensuse.org/archives/list/project@lists.opensuse.org/thread/7TRFBOW6IYBAQD2FJCHAHBZSGJP43SCU/#KKOYNMOLN577DREPKWPYQXA6MBCOILLL